### PR TITLE
Add experiment creation

### DIFF
--- a/cmds/create_experiment.go
+++ b/cmds/create_experiment.go
@@ -1,0 +1,78 @@
+package cmds
+
+import (
+	"fmt"
+
+	"github.com/Betterment/testtrack-cli/migrationmanagers"
+	"github.com/Betterment/testtrack-cli/splits"
+	"github.com/Betterment/testtrack-cli/validations"
+	"github.com/spf13/cobra"
+)
+
+var createExperimentDoc = `
+Creates or updates an experiment split in TestTrack.
+
+Example:
+
+testtrack create experiment my_fancy_experiment
+
+Experiments will default to having two variants, control and treatment, with
+weightings of 50% each.
+
+Weights are specified as a string and must sum to 100:
+
+--weights "variant_1: 25, variant_2: 25, variant_3: 50"
+`
+
+var createExperimentWeights string
+
+func init() {
+	createExperimentCmd.Flags().StringVar(&createExperimentWeights, "weights", "control: 50, treatment: 50", "Variant weights to use")
+	createCmd.AddCommand(createExperimentCmd)
+}
+
+var createExperimentCmd = &cobra.Command{
+	Use:   "experiment name",
+	Short: "Create or update an experiment's configuration",
+	Long:  createExperimentDoc,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return createExperiment(args[0], createExperimentWeights)
+	},
+}
+
+func createExperiment(name, weights string) error {
+	appName, err := getAppName()
+	if err != nil {
+		return err
+	}
+
+	err = validations.NonPrefixedExperiment("name", &name)
+	if err != nil {
+		return err
+	}
+
+	name = fmt.Sprintf("%s.%s", appName, name)
+
+	weightsMap, err := splits.WeightsFromString(weights)
+	if err != nil {
+		return err
+	}
+
+	split, err := splits.New(&name, weightsMap)
+	if err != nil {
+		return err
+	}
+
+	mgr, err := migrationmanagers.New(split)
+	if err != nil {
+		return err
+	}
+
+	err = mgr.Save()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmds/create_feature_completion.go
+++ b/cmds/create_feature_completion.go
@@ -26,10 +26,10 @@ field for customers to use.
 You can reverse complete_feature with the uncomplete_feature command.
 `
 
-var appVersion string
+var createFeatureCompletionAppVersion string
 
 func init() {
-	createFeatureCompletionCmd.Flags().StringVar(&appVersion, "app_version", "", "App version (required)")
+	createFeatureCompletionCmd.Flags().StringVar(&createFeatureCompletionAppVersion, "app_version", "", "App version (required)")
 	createFeatureCompletionCmd.MarkFlagRequired("app_version")
 	createCmd.AddCommand(createFeatureCompletionCmd)
 }
@@ -40,7 +40,7 @@ var createFeatureCompletionCmd = &cobra.Command{
 	Long:  createFeatureCompletionDoc,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return createFeatureCompletion(&args[0], &appVersion)
+		return createFeatureCompletion(&args[0], &createFeatureCompletionAppVersion)
 	},
 }
 

--- a/cmds/create_remote_kill.go
+++ b/cmds/create_remote_kill.go
@@ -30,14 +30,14 @@ the bug can be fixed and then undecide it afterward.
 You can reverse remote_kills with the destroy remote_kill command.
 `
 
-var overrideTo, firstBadVersion, fixedVersion string
+var createRemoteKillOverrideTo, createRemoteKillFirstBadVersion, createRemoteKillFixedVersion string
 
 func init() {
-	createRemoteKillCmd.Flags().StringVar(&overrideTo, "override_to", "", "Override-to variant (required)")
+	createRemoteKillCmd.Flags().StringVar(&createRemoteKillOverrideTo, "override_to", "", "Override-to variant (required)")
 	createRemoteKillCmd.MarkFlagRequired("override_to")
-	createRemoteKillCmd.Flags().StringVar(&firstBadVersion, "first_bad_version", "", "First bad app version (required)")
+	createRemoteKillCmd.Flags().StringVar(&createRemoteKillFirstBadVersion, "first_bad_version", "", "First bad app version (required)")
 	createRemoteKillCmd.MarkFlagRequired("first_bad_version")
-	createRemoteKillCmd.Flags().StringVar(&firstBadVersion, "fixed_version", "", "Fixed app version")
+	createRemoteKillCmd.Flags().StringVar(&createRemoteKillFixedVersion, "fixed_version", "", "Fixed app version")
 	createCmd.AddCommand(createRemoteKillCmd)
 }
 
@@ -47,7 +47,7 @@ var createRemoteKillCmd = &cobra.Command{
 	Long:  createRemoteKillDoc,
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return createRemoteKill(&args[0], &args[1], &overrideTo, &firstBadVersion, &fixedVersion)
+		return createRemoteKill(&args[0], &args[1], &createRemoteKillOverrideTo, &createRemoteKillFirstBadVersion, &createRemoteKillFixedVersion)
 	},
 }
 

--- a/cmds/root.go
+++ b/cmds/root.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -12,7 +13,9 @@ var version string
 var build string
 
 func init() {
-	if _, ok := os.LookupEnv("TESTTRACK_CLI_URL"); !ok {
+	_, urlSet := os.LookupEnv("TESTTRACK_CLI_URL")
+	_, appNameSet := os.LookupEnv("TESTTRACK_APP_NAME")
+	if !urlSet && !appNameSet {
 		godotenv.Load()
 	}
 }
@@ -33,4 +36,12 @@ func Execute() {
 		}
 		os.Exit(1)
 	}
+}
+
+func getAppName() (string, error) {
+	appName, ok := os.LookupEnv("TESTTRACK_APP_NAME")
+	if !ok {
+		return "", errors.New("TESTTRACK_APP_NAME must be set")
+	}
+	return appName, nil
 }

--- a/validations/validations.go
+++ b/validations/validations.go
@@ -61,6 +61,20 @@ func Split(paramName string, value *string) error {
 	return nil
 }
 
+// NonPrefixedExperiment validates that an experiment name param is valid with
+// no app prefix
+func NonPrefixedExperiment(paramName string, value *string) error {
+	err := NonPrefixedSplit(paramName, value)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasSuffix(*value, "_experiment") {
+		return fmt.Errorf("%s '%s' must end in _experiment", paramName, *value)
+	}
+	return nil
+}
+
 // NonPrefixedFeatureGate validates that a `feature_gate_name` param is valid
 func NonPrefixedFeatureGate(paramName string, value *string) error {
 	err := NonPrefixedSplit(paramName, value)


### PR DESCRIPTION
/domain @samandmoore @smudge 
/platform @samandmoore 

Now we've got all the split creation commands we need - there will never be the ability to create a split that doesn't conform to our conventions of a feature_gate or an experiment in the CLI migrator.