### PR TITLE
Allow custom CORS origins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=0.9.5
+VERSION=0.9.6
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \


### PR DESCRIPTION
/domain @samandmoore @smudge 
/no-platform

We still default to allowing .test if no TESTTRACK_ALLOWED_ORIGINS env var is provided.

Bump to 0.9.6 for another release as well.