### PR TITLE
v0.9.8 - server still works if a schema symlink is broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=0.9.7
+VERSION=0.9.8
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -109,7 +109,7 @@ func ReadMerged() (*serializers.Schema, error) {
 		if fi.Mode()&os.ModeSymlink != 0 {
 			path, err = os.Readlink(path)
 			if err != nil {
-				return nil, err
+				continue // It's OK if this symlink isn't traversable (e.g. app was uninstalled), we'll just skip it.
 			}
 		}
 		// Read file


### PR DESCRIPTION
/domain @samandmoore @smudge 
/no-platform

This will allow the server to continue to work if somebody switches to a stale branch that doesn't have a schema file yet, or if an app is removed from the dev machine.