### PR TITLE
Refactor internal naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=0.9.8
+VERSION=0.9.9
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/cmds/create_experiment.go
+++ b/cmds/create_experiment.go
@@ -82,7 +82,7 @@ func createExperiment(name, weights string) error {
 		return err
 	}
 
-	err = mgr.Save()
+	err = mgr.CreateMigration()
 	if err != nil {
 		return err
 	}

--- a/cmds/create_feature_completion.go
+++ b/cmds/create_feature_completion.go
@@ -81,7 +81,7 @@ func createFeatureCompletion(featureGate, version *string) error {
 		return err
 	}
 
-	err = mgr.Save()
+	err = mgr.CreateMigration()
 	if err != nil {
 		return err
 	}

--- a/cmds/create_feature_gate.go
+++ b/cmds/create_feature_gate.go
@@ -110,7 +110,7 @@ func createFeatureGate(name, defaultVariant, weights string) error {
 		return err
 	}
 
-	err = mgr.Save()
+	err = mgr.CreateMigration()
 	if err != nil {
 		return err
 	}

--- a/cmds/create_identifier_type.go
+++ b/cmds/create_identifier_type.go
@@ -49,7 +49,7 @@ func createIdentifierType(name string) error {
 		return err
 	}
 
-	err = mgr.Save()
+	err = mgr.CreateMigration()
 	if err != nil {
 		return err
 	}

--- a/cmds/create_remote_kill.go
+++ b/cmds/create_remote_kill.go
@@ -88,7 +88,7 @@ func createRemoteKill(split, reason, overrideTo, firstBadVersion, fixedVersion *
 		return err
 	}
 
-	err = mgr.Save()
+	err = mgr.CreateMigration()
 	if err != nil {
 		return err
 	}

--- a/cmds/decide.go
+++ b/cmds/decide.go
@@ -78,7 +78,7 @@ func decide(name, variant string) error {
 		return err
 	}
 
-	err = mgr.Save()
+	err = mgr.CreateMigration()
 	if err != nil {
 		return err
 	}

--- a/cmds/destroy_feature_completion.go
+++ b/cmds/destroy_feature_completion.go
@@ -59,7 +59,7 @@ func destroyFeatureCompletion(featureGate *string) error {
 		return err
 	}
 
-	err = mgr.Save()
+	err = mgr.CreateMigration()
 	if err != nil {
 		return err
 	}

--- a/cmds/destroy_remote_kill.go
+++ b/cmds/destroy_remote_kill.go
@@ -57,7 +57,7 @@ func destroyRemoteKill(split, reason *string) error {
 		return err
 	}
 
-	err = mgr.Save()
+	err = mgr.CreateMigration()
 	if err != nil {
 		return err
 	}

--- a/cmds/destroy_split.go
+++ b/cmds/destroy_split.go
@@ -83,7 +83,7 @@ func destroySplit(name, decision string) error {
 		return err
 	}
 
-	err = mgr.Save()
+	err = mgr.CreateMigration()
 	if err != nil {
 		return err
 	}

--- a/migrationmanagers/migrationmanagers.go
+++ b/migrationmanagers/migrationmanagers.go
@@ -44,9 +44,9 @@ func NewWithDependencies(migration migrations.IMigration, server servers.IServer
 	}
 }
 
-// Save does the whole operation of validating and persisting a
+// CreateMigration does the whole operation of validating and persisting a
 // migration to disk, and updating the schema
-func (m *MigrationManager) Save() error {
+func (m *MigrationManager) CreateMigration() error {
 	err := m.migration.Validate()
 	if err != nil {
 		return err
@@ -69,9 +69,9 @@ func (m *MigrationManager) Save() error {
 	return schema.Write(m.schema)
 }
 
-// Run applies a migration to the TestTrack server, writing out the schema
-func (m *MigrationManager) Run(migrationRepo migrations.Repository) error {
-	err := m.Apply(migrationRepo)
+// Migrate syncs a migration and its version to the TestTrack server
+func (m *MigrationManager) Migrate() error {
+	err := m.Sync()
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (m *MigrationManager) Run(migrationRepo migrations.Repository) error {
 	if err != nil {
 		return err
 	}
-	return schema.Write(m.schema)
+	return nil
 }
 
 // ApplyToSchema validates and applies a migration to the in-memory schema representation
@@ -101,18 +101,13 @@ func (m *MigrationManager) ApplyToSchema(migrationRepo migrations.Repository, id
 	return nil
 }
 
-// Apply idempotently applies a migration to the TestTrack server and in-memory
-// schema without recording the version to TestTrack server
-func (m *MigrationManager) Apply(migrationRepo migrations.Repository) error {
+// Sync applies the contents of a migration to the TestTrack server
+func (m *MigrationManager) Sync() error {
 	err := m.migration.Validate()
 	if err != nil {
 		return err
 	}
 
-	err = m.migration.ApplyToSchema(m.schema, migrationRepo, true)
-	if err != nil {
-		return err
-	}
 	resp, err := m.server.Post(m.migration.SyncPath(), m.migration.Serializable())
 	if err != nil {
 		return err

--- a/migrationmanagers/migrationmanagers.go
+++ b/migrationmanagers/migrationmanagers.go
@@ -35,12 +35,12 @@ func New(migration migrations.IMigration) (*MigrationManager, error) {
 	}, nil
 }
 
-// NewWithDependencies returns a MigrationManager using a provided Server
-func NewWithDependencies(migration migrations.IMigration, server servers.IServer, schema *serializers.Schema) *MigrationManager {
+// NewWithServer returns a MigrationManager using a provided Server
+func NewWithServer(migration migrations.IMigration, server servers.IServer) *MigrationManager {
 	return &MigrationManager{
 		migration: migration,
 		server:    server,
-		schema:    schema,
+		schema:    &serializers.Schema{},
 	}
 }
 

--- a/migrationrunners/migrationrunners.go
+++ b/migrationrunners/migrationrunners.go
@@ -35,7 +35,7 @@ func (r *Runner) RunOutstanding() error {
 	versions := migrationRepo.SortedVersions()
 
 	for _, version := range versions {
-		mgr := migrationmanagers.NewWithDependencies(migrationRepo[version], r.server, r.schema)
+		mgr := migrationmanagers.NewWithServer(migrationRepo[version], r.server)
 		err := mgr.Migrate()
 		if err != nil {
 			return err

--- a/migrationrunners/migrationrunners.go
+++ b/migrationrunners/migrationrunners.go
@@ -3,6 +3,7 @@ package migrationrunners
 import (
 	"github.com/Betterment/testtrack-cli/migrationloaders"
 	"github.com/Betterment/testtrack-cli/migrationmanagers"
+	"github.com/Betterment/testtrack-cli/migrations"
 	"github.com/Betterment/testtrack-cli/schema"
 	"github.com/Betterment/testtrack-cli/serializers"
 	"github.com/Betterment/testtrack-cli/servers"
@@ -26,31 +27,39 @@ func New(server servers.IServer) (*Runner, error) {
 
 // RunOutstanding runs all outstanding migrations
 func (r *Runner) RunOutstanding() error {
-	migrationRepo, err := migrationloaders.Load()
+	migrationRepo, err := r.getOutstandingMigrations()
 	if err != nil {
 		return err
-	}
-
-	appliedMigrationVersions, err := r.getAppliedMigrationVersions()
-	if err != nil {
-		return err
-	}
-
-	for _, version := range appliedMigrationVersions {
-		delete(migrationRepo, version.Version)
 	}
 
 	versions := migrationRepo.SortedVersions()
 
 	for _, version := range versions {
 		mgr := migrationmanagers.NewWithDependencies(migrationRepo[version], r.server, r.schema)
-		err := mgr.Run(migrationRepo)
+		err := mgr.Migrate()
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func (r *Runner) getOutstandingMigrations() (migrations.Repository, error) {
+	migrationRepo, err := migrationloaders.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	appliedMigrationVersions, err := r.getAppliedMigrationVersions()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, version := range appliedMigrationVersions {
+		delete(migrationRepo, version.Version)
+	}
+	return migrationRepo, nil
 }
 
 func (r *Runner) getAppliedMigrationVersions() ([]serializers.MigrationVersion, error) {

--- a/schemaloaders/schemaloaders.go
+++ b/schemaloaders/schemaloaders.go
@@ -72,7 +72,7 @@ func (s *SchemaLoader) Load() error {
 		SchemaVersion:     s.schema.SchemaVersion,
 	}
 	for _, migration := range ms {
-		err := migrationmanagers.NewWithDependencies(migration, s.server, newSchema).Apply(migrations.Repository{}) // generated migrations are data-complete and don't need migrations
+		err := migrationmanagers.NewWithDependencies(migration, s.server, newSchema).Sync()
 		if err != nil {
 			return err
 		}

--- a/schemaloaders/schemaloaders.go
+++ b/schemaloaders/schemaloaders.go
@@ -2,7 +2,6 @@ package schemaloaders
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/Betterment/testtrack-cli/featurecompletions"
 	"github.com/Betterment/testtrack-cli/identifiertypes"
@@ -16,7 +15,6 @@ import (
 	"github.com/Betterment/testtrack-cli/splitdecisions"
 	"github.com/Betterment/testtrack-cli/splits"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 )
 
 // SchemaLoader loads schemas into TestTrack
@@ -76,19 +74,6 @@ func (s *SchemaLoader) Load() error {
 		if err != nil {
 			return err
 		}
-	}
-
-	schema.SortAlphabetically(newSchema)
-	if !reflect.DeepEqual(*s.schema, *newSchema) {
-		before, err := yaml.Marshal(s.schema)
-		if err != nil {
-			return err
-		}
-		after, err := yaml.Marshal(newSchema)
-		if err != nil {
-			return err
-		}
-		return fmt.Errorf("testtrack bug! load resulted in different schema.\n\nBefore:\n\n%s\n\nAfter:\n\n%s", before, after)
 	}
 
 	for _, version := range s.migrationRepo.SortedVersions() {

--- a/schemaloaders/schemaloaders.go
+++ b/schemaloaders/schemaloaders.go
@@ -65,12 +65,8 @@ func (s *SchemaLoader) Load() error {
 		ms = append(ms, featurecompletions.FromFile(nil, &s.schema.FeatureCompletions[i]))
 	}
 
-	newSchema := &serializers.Schema{
-		SerializerVersion: serializers.SerializerVersion,
-		SchemaVersion:     s.schema.SchemaVersion,
-	}
 	for _, migration := range ms {
-		err := migrationmanagers.NewWithDependencies(migration, s.server, newSchema).Sync()
+		err := migrationmanagers.NewWithServer(migration, s.server).Sync()
 		if err != nil {
 			return err
 		}
@@ -81,7 +77,7 @@ func (s *SchemaLoader) Load() error {
 			fmt.Println("Schema load complete, but there are migrations newer than the schema file - run testtrack migrate to apply them.")
 			break
 		}
-		err := migrationmanagers.NewWithDependencies((*s.migrationRepo)[version], s.server, newSchema).SyncVersion()
+		err := migrationmanagers.NewWithServer((*s.migrationRepo)[version], s.server).SyncVersion()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
/domain @samandmoore @smudge 
/platform @samandmoore @smudge 

Trying to land this refactor before I totally forget how the internals work.

It's more than naming, but it also satisfies the invariants we need. I'm going to attempt to justify the changes below. I extracted this naming refactor from a bigger change that Sam isn't sure about that adds a `check` command to verify that running outstanding migrations would result in a schema that matches the present schema, basically a way to detect that migration order would result in divergent state between production and the schema file. But we maybe don't need that feature.