### PR TITLE
Document no prefix for create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=1.0
+VERSION=0.9.10
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=0.9.10
+VERSION=0.9.9
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=0.9.9
+VERSION=1.0
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/cmds/create_experiment.go
+++ b/cmds/create_experiment.go
@@ -23,13 +23,17 @@ weightings of 50% each.
 Weights are specified as a string and must sum to 100:
 
 --weights "variant_1: 25, variant_2: 25, variant_3: 50"
+
+Do not use --no-prefix to create a new split. It can be used to revive a
+destroyed split if it was destroyed by mistake, but the migration will fail if
+you attempt to create a new split without a prefix.
 `
 
 var createExperimentWeights string
 
 func init() {
 	createExperimentCmd.Flags().StringVar(&createExperimentWeights, "weights", "control: 50, treatment: 50", "Variant weights to use")
-	createExperimentCmd.Flags().BoolVar(&noPrefix, "no-prefix", false, "Don't prefix experiment with app_name (supports legacy splits)")
+	createExperimentCmd.Flags().BoolVar(&noPrefix, "no-prefix", false, "Don't prefix experiment with app_name (supports existing legacy splits)")
 	createCmd.AddCommand(createExperimentCmd)
 }
 

--- a/cmds/create_feature_gate.go
+++ b/cmds/create_feature_gate.go
@@ -27,6 +27,10 @@ Optional weights are specified as a string, must have the variants true and
 false, and must sum to 100:
 
 --weights "true: 25, false: 75"
+
+Do not use --no-prefix to create a new split. It can be used to revive a
+destroyed split if it was destroyed by mistake, but the migration will fail if
+you attempt to create a new split without a prefix.
 `
 
 var createFeatureGateDefault, createFeatureGateWeights string
@@ -34,7 +38,7 @@ var createFeatureGateDefault, createFeatureGateWeights string
 func init() {
 	createFeatureGateCmd.Flags().StringVar(&createFeatureGateDefault, "default", "false", "Default variant for your feature flag")
 	createFeatureGateCmd.Flags().StringVar(&createFeatureGateWeights, "weights", "", "Variant weights to use (overrides default)")
-	createFeatureGateCmd.Flags().BoolVar(&noPrefix, "no-prefix", false, "Don't prefix feature gate with app_name (supports legacy splits)")
+	createFeatureGateCmd.Flags().BoolVar(&noPrefix, "no-prefix", false, "Don't prefix feature gate with app_name (supports existing legacy splits)")
 	createCmd.AddCommand(createFeatureGateCmd)
 }
 


### PR DESCRIPTION
/domain @samandmoore for testtrack v1.0 - we ready?
/domain @rnackman @joejansen for the doc fixes - does this work? I wanted to keep the parameter documentation tight, so i put `existing` in there to prompt doubt, and then put the full details in the `--help` documentation for both experiment and feature_flag creation commands.

fixes #37