### PR TITLE
Add fake v2 split registry

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,3 @@
+brew 'dep'
+brew 'go'
 brew 'hub'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The `testtrack` CLI has the following features:
 
 1. Download/install testtrack CLI
 
-Currently TestTrack binaries for linux and OS X are distributed via [GitHub releases](https://github.com/Betterment/testtrack-cli/releases). We'll add a homebrew tap soon to assist in installing and daemonizing the server on OS X.
+Currently TestTrack binaries for linux and macOS are distributed via [GitHub releases](https://github.com/Betterment/testtrack-cli/releases). We'll add a homebrew tap soon to assist in installing and daemonizing the server on macOS.
 
 2. Initialize your project
 
@@ -71,3 +71,23 @@ testtrack create feature_gate my_new_feature_q2_2019_enabled
 Just run `testtrack help` for more documentation on how to configure splits and other TestTrack resources.
 
 Happy TestTracking!
+
+## How to Contribute
+
+We would love for you to contribute! Anything that benefits the majority of TestTrack users—from a documentation fix to an entirely new feature—is encouraged.
+
+Before diving in, [check our issue tracker](https://github.com/Betterment/testtrack-cli/issues) and consider creating a new issue to get early feedback on your proposed change.
+
+### Suggested Workflow
+
+* Fork the project and create a new branch for your contribution.
+* Write your contribution (and any applicable test coverage).
+* Make sure all tests pass (`make test`).
+* Submit a pull request.
+
+### Some tips for those new to golang
+
+* Set up your workspace according to [go standards](https://golang.org/doc/code.html#Organization).
+* For macOS and homebrew users, run `brew bundle` to install `go` itself.
+* Run `dep ensure` to install go dependencies.
+* Build and run the CLI using `go run testtrack/main.go`.

--- a/cmds/server.go
+++ b/cmds/server.go
@@ -10,7 +10,12 @@ Run a fake TestTrack server for local development, backed by schema.yml files
 and nonsense.
 `
 
+var listenOn string
+
+const defaultListenOn = "127.0.0.1:8297"
+
 func init() {
+	serverCmd.Flags().StringVarP(&listenOn, "listen", "l", defaultListenOn, "IP address and port to listen on")
 	rootCmd.AddCommand(serverCmd)
 }
 
@@ -20,7 +25,7 @@ var serverCmd = &cobra.Command{
 	Long:  serverDoc,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fakeserver.Start()
+		fakeserver.Start(listenOn)
 		return nil
 	},
 }

--- a/cmds/server.go
+++ b/cmds/server.go
@@ -10,12 +10,12 @@ Run a fake TestTrack server for local development, backed by schema.yml files
 and nonsense.
 `
 
-var listenOn string
+var port int
 
-const defaultListenOn = "127.0.0.1:8297"
+const defaultPort = 8297
 
 func init() {
-	serverCmd.Flags().StringVarP(&listenOn, "listen", "l", defaultListenOn, "IP address and port to listen on")
+	serverCmd.Flags().IntVarP(&port, "listen", "l", defaultPort, "Port to listen on")
 	rootCmd.AddCommand(serverCmd)
 }
 
@@ -25,7 +25,7 @@ var serverCmd = &cobra.Command{
 	Long:  serverDoc,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fakeserver.Start(listenOn)
+		fakeserver.Start(port)
 		return nil
 	},
 }

--- a/cmds/server.go
+++ b/cmds/server.go
@@ -15,7 +15,7 @@ var port int
 const defaultPort = 8297
 
 func init() {
-	serverCmd.Flags().IntVarP(&port, "listen", "l", defaultPort, "Port to listen on")
+	serverCmd.Flags().IntVarP(&port, "port", "p", defaultPort, "Port to listen on")
 	rootCmd.AddCommand(serverCmd)
 }
 

--- a/fakeserver/routes.go
+++ b/fakeserver/routes.go
@@ -28,21 +28,21 @@ type v1Assignment struct {
 
 // v1VisitorConfig is the JSON output type for V1 visitor_config endpoints
 type v1VisitorConfig struct {
-	Splits  interface{} `json:"splits"`
-	Visitor interface{} `json:"visitor"`
+	Splits  map[string]*splits.Weights `json:"splits"`
+	Visitor v1Visitor                  `json:"visitor"`
 }
 
 // v2VisitorConfig is the JSON output type for V2 visitor_config endpoints
 type v2VisitorConfig struct {
-	Splits                   interface{} `json:"splits"`
-	Visitor                  interface{} `json:"visitor"`
-	ExperienceSamplingWeight int         `json:"experience_sampling_weight"`
+	Splits                   map[string]*v2Split `json:"splits"`
+	Visitor                  v1Visitor           `json:"visitor"`
+	ExperienceSamplingWeight int                 `json:"experience_sampling_weight"`
 }
 
 // v2SplitRegistry is the JSON output type for V2 split_registry endpoint
 type v2SplitRegistry struct {
-	Splits                   interface{} `json:"splits"`
-	ExperienceSamplingWeight int         `json:"experience_sampling_weight"`
+	Splits                   map[string]*v2Split `json:"splits"`
+	ExperienceSamplingWeight int                 `json:"experience_sampling_weight"`
 }
 
 // v2SplitRegistry is the JSON output type for V2 split_registry endpoint
@@ -254,11 +254,13 @@ func postV1AssignmentOverride(r *http.Request) error {
 }
 
 func getV1AppVisitorConfig() (interface{}, error) {
-	splitRegistry, err := getV1SplitRegistry()
+	isplitRegistry, err := getV1SplitRegistry()
+	splitRegistry := isplitRegistry.(map[string]*splits.Weights)
 	if err != nil {
 		return nil, err
 	}
-	visitor, err := getV1Visitor()
+	ivisitor, err := getV1Visitor()
+	visitor := ivisitor.(v1Visitor)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +276,8 @@ func getV2AppVisitorConfig() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	visitor, err := getV1Visitor()
+	ivisitor, err := getV1Visitor()
+	visitor := ivisitor.(v1Visitor)
 	if err != nil {
 		return nil, err
 	}

--- a/fakeserver/server.go
+++ b/fakeserver/server.go
@@ -25,7 +25,7 @@ type server struct {
 }
 
 // Start the server
-func Start(listenOn string) {
+func Start(port int) {
 	var wait time.Duration
 	flag.DurationVar(&wait, "graceful-timeout", time.Second*15, "the duration for which the server gracefully wait for existing connections to finish - e.g. 15s or 1m")
 	flag.Parse()
@@ -34,6 +34,8 @@ func Start(listenOn string) {
 
 	s := &server{router: r}
 	s.routes()
+
+	listenOn := fmt.Sprintf("127.0.0.1:%d", port)
 
 	// Run our server in a goroutine so that it doesn't block.
 	fmt.Printf("testtrack server listening on %s\n", listenOn)

--- a/fakeserver/server.go
+++ b/fakeserver/server.go
@@ -20,15 +20,12 @@ import (
 // writing inconsistent state from/to the filesystem
 var mutex sync.Mutex
 
-// BindTo is the IP and port we're binding to
-const BindTo = "127.0.0.1:8297"
-
 type server struct {
 	router *mux.Router
 }
 
 // Start the server
-func Start() {
+func Start(listenOn string) {
 	var wait time.Duration
 	flag.DurationVar(&wait, "graceful-timeout", time.Second*15, "the duration for which the server gracefully wait for existing connections to finish - e.g. 15s or 1m")
 	flag.Parse()
@@ -39,8 +36,8 @@ func Start() {
 	s.routes()
 
 	// Run our server in a goroutine so that it doesn't block.
-	fmt.Printf("testtrack server binding to %s\n", BindTo)
-	log.Fatal(http.ListenAndServe(BindTo, cors.New(cors.Options{
+	fmt.Printf("testtrack server listening on %s\n", listenOn)
+	log.Fatal(http.ListenAndServe(listenOn, cors.New(cors.Options{
 		AllowCredentials: true,
 		AllowedHeaders:   []string{"authorization"},
 		AllowOriginFunc: func(origin string) bool {

--- a/splits/splits.go
+++ b/splits/splits.go
@@ -74,6 +74,11 @@ func WeightsFromString(weights string) (*Weights, error) {
 	return &result, nil
 }
 
+// IsFeatureGateFromName returns true if name ends with '_enabled'
+func IsFeatureGateFromName(name string) bool {
+	return strings.HasSuffix(name, "_enabled")
+}
+
 // FromFile reifies a migration from the yaml serializable representation
 func FromFile(migrationVersion *string, serializable *serializers.SplitYAML) (migrations.IMigration, error) {
 	weights, err := WeightsFromYAML(serializable.Weights)


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/platform @jmileham 

Added fake endpoints for v2 split registry and visitor config. Also introduced a flag to set the ip/port that the fake server listens on, to ease local development while another TT fake server may be running. Fixes #39.