### PR TITLE
Add request logging to fake server

### DIFF
--- a/cmds/server.go
+++ b/cmds/server.go
@@ -11,11 +11,13 @@ and nonsense.
 `
 
 var port int
+var logRequests bool
 
 const defaultPort = 8297
 
 func init() {
 	serverCmd.Flags().IntVarP(&port, "port", "p", defaultPort, "Port to listen on")
+	serverCmd.Flags().BoolVarP(&logRequests, "log-requests", "", false, "Log requests to stderr")
 	rootCmd.AddCommand(serverCmd)
 }
 
@@ -25,7 +27,7 @@ var serverCmd = &cobra.Command{
 	Long:  serverDoc,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fakeserver.Start(port)
+		fakeserver.Start(port, logRequests)
 		return nil
 	},
 }

--- a/cmds/server.go
+++ b/cmds/server.go
@@ -11,13 +11,11 @@ and nonsense.
 `
 
 var port int
-var logRequests bool
 
 const defaultPort = 8297
 
 func init() {
 	serverCmd.Flags().IntVarP(&port, "port", "p", defaultPort, "Port to listen on")
-	serverCmd.Flags().BoolVarP(&logRequests, "log-requests", "", false, "Log requests to stderr")
 	rootCmd.AddCommand(serverCmd)
 }
 
@@ -27,7 +25,7 @@ var serverCmd = &cobra.Command{
 	Long:  serverDoc,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fakeserver.Start(port, logRequests)
+		fakeserver.Start(port)
 		return nil
 	},
 }


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/platform @jmileham 

I added some very basic logging to make testing a little easier. It's disabled by default and looks like:

`2019/06/14 11:44:40 127.0.0.1:53261 GET /api/v2/split_registry`