### PR TITLE
Cors module does not work as middleware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=1.0.0
+VERSION=1.0.1
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/fakeserver/server.go
+++ b/fakeserver/server.go
@@ -31,7 +31,7 @@ func loggingMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func corsMiddleware(next http.Handler) http.Handler {
+func createCors() *cors.Cors {
 	return cors.New(cors.Options{
 		AllowCredentials: true,
 		AllowedHeaders:   []string{"authorization"},
@@ -59,7 +59,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 			}
 			return false
 		},
-	}).Handler(next)
+	})
 }
 
 // Start the server
@@ -72,11 +72,12 @@ func Start(port int) {
 	s.routes()
 
 	r.Use(loggingMiddleware)
-	r.Use(corsMiddleware)
+
+	handler := createCors().Handler(r)
 
 	listenOn := fmt.Sprintf("127.0.0.1:%d", port)
 	logger.Printf("testtrack server listening on %s", listenOn)
-	logger.Fatalf("fatal - %s", http.ListenAndServe(listenOn, r))
+	logger.Fatalf("fatal - %s", http.ListenAndServe(listenOn, handler))
 }
 
 func (s *server) handleGet(pattern string, responseFunc func() (interface{}, error)) {


### PR DESCRIPTION
/domain @jmileham 
/no-platform
/cc @fidelscodes @rnackman 

Middleware only executes on matching routes. Since we don't explicitly define our routes to support the OPTIONS method, none of our routes would match a CORS OPTIONS request.

In the earlier implementation, we were executing the CORS handler outside of the middleware stack, so it didn't depend on a matching route, it would run regardless.

So I'm switching back to that implementation. The alternative would be to specify that our routes support both POST and OPTIONS, but that seemed more fragile.