### PR TITLE
Grab golint from golang.org

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,17 +10,6 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "travis-1.9"
-  digest = "1:d45f5fe0f8bf6cd0bc592502e7e8ec647d769e55387fe326eb624d67282a7d15"
-  name = "github.com/golang/lint"
-  packages = [
-    ".",
-    "golint",
-  ]
-  pruneopts = ""
-  revision = "883fe33ffc4344bad1ecd881f61afd5ec5d80e0a"
-
-[[projects]]
   digest = "1:65c7ed49d9f36dd4752e43013323fa9229db60b29aa4f5a75aaecda3130c74e2"
   name = "github.com/gorilla/mux"
   packages = ["."]
@@ -97,6 +86,17 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:07a6b419f790dba389a58ba7ef5bb5e5281fe0b3046398b33767e3bd21c0b736"
+  name = "golang.org/x/lint"
+  packages = [
+    ".",
+    "golint",
+  ]
+  pruneopts = ""
+  revision = "16217165b5de779cb6a5e4fc81fa9c1166fda457"
+
+[[projects]]
+  branch = "master"
   digest = "1:8eb8d3e3ac8104f933168344d8961d774cfeecc8340a65a4b0ca01b273fcda9d"
   name = "golang.org/x/tools"
   packages = [
@@ -128,13 +128,13 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/golang/lint/golint",
     "github.com/gorilla/mux",
     "github.com/joho/godotenv",
     "github.com/pkg/errors",
     "github.com/rs/cors",
     "github.com/spf13/cobra",
     "github.com/stretchr/testify/require",
+    "golang.org/x/lint/golint",
     "golang.org/x/tools/cmd/goimports",
     "gopkg.in/yaml.v2",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,4 +20,4 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
-required = ["golang.org/x/tools/cmd/goimports", "github.com/golang/lint/golint"]
+required = ["golang.org/x/tools/cmd/goimports", "golang.org/x/lint/golint"]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ release: distclean dist
 
 test:
 	@go install ./vendor/golang.org/x/tools/cmd/goimports
-	@go install ./vendor/github.com/golang/lint/golint
+	@go install ./vendor/golang.org/x/lint/golint
 	@GOIMPORTS_RESULT=$$(goimports -l ${PACKAGES} | grep -v ${LINTEXCLUDES});\
 		if [ $$(echo "$$GOIMPORTS_RESULT\c" | head -c1 | wc -c) -ne 0 ];\
 			then\


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform
/cc @reggieag @andimrob 

We were depending on a version of golint from github and from a branch that no longer exists. This updates our dependency to a version from golang.org, which (I think) is the canonical source.