### PR TITLE
Add fake v2 split registry timestamp route

### DIFF
--- a/fakeserver/routes.go
+++ b/fakeserver/routes.go
@@ -88,6 +88,10 @@ func (s *server) routes() {
 		"/api/v2/split_registry",
 		getV2SplitRegistry,
 	)
+	s.handleGet(
+		"/api/v2/split_registry/{ts}",
+		getV2SplitRegistry,
+	)
 	s.handlePostReturnNoContent(
 		"/api/v1/assignment_event",
 		postNoop,


### PR DESCRIPTION
/domain @Betterment/test_track_core
/platform @aburgel 

Add a route for V2 split registry to enable passing in a timestamp