### PR TITLE
Adding generate_timestamp to cli

### DIFF
--- a/cmds/generate_timestamp.go
+++ b/cmds/generate_timestamp.go
@@ -2,17 +2,15 @@ package cmds
 
 import (
 	"io/ioutil"
-	"log"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
 )
 
 var generateTimestampDoc = `
-Write the current UTC timestamp to the file 'testtrack/build_timestamp.txt' in a
-TestTrack project. This timestamp can be passed as a param by the TestTrack
-client when calling the split registry endpoint from the TestTrack server.
+Write the current UTC timestamp to the file 'testtrack/build_timestamp.txt'.
+This timestamp is used by TestTrack clients to request the version of the split
+registry active at the given time.
 `
 
 func init() {
@@ -33,14 +31,5 @@ func generateTimestamp() error {
 	const buildTimestampPath = "testtrack/build_timestamp.txt"
 	timestamp := []byte(time.Now().UTC().Format("2006-01-02T15:04:05Z"))
 
-	err := ioutil.WriteFile(buildTimestampPath, timestamp, 0644)
-	if e, ok := err.(*os.PathError); ok {
-		if e.Path == buildTimestampPath {
-			log.Fatal("Testtrack Directory Not Found: Make sure you are in a TestTrack project")
-		}
-	} else if err != nil {
-		log.Fatal(err)
-	}
-
-	return nil
+	return ioutil.WriteFile(buildTimestampPath, timestamp, 0644)
 }

--- a/cmds/generate_timestamp.go
+++ b/cmds/generate_timestamp.go
@@ -2,18 +2,15 @@ package cmds
 
 import (
 	"io/ioutil"
-	"os"
-	"os/user"
-	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
 )
 
 var generateTimestampDoc = `
-Write the current timestamp to the file '~/.testtrack/build_timestamp.txt'.
-This timestamp can be passed as a param by the Testtrack client when calling the
-split registry endpoint from the Testtrack server.
+Write the current timestamp to the file 'build_timestamp.txt' in a TestTrack project.
+This timestamp can be passed as a param by the TestTrack client when calling the
+split registry endpoint from the TestTrack server.
 `
 
 func init() {
@@ -22,7 +19,7 @@ func init() {
 
 var generateTimestampCmd = &cobra.Command{
 	Use:   "generate_timestamp",
-	Short: "Write the current timestamp to '~/.testtrack/build_timestamp.txt'",
+	Short: "Write the current timestamp to 'testtrack/build_timestamp.txt'",
 	Long:  generateTimestampDoc,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -31,19 +28,8 @@ var generateTimestampCmd = &cobra.Command{
 }
 
 func generateTimestamp() error {
-	usr, _ := user.Current()
-	TimestampDir := filepath.Join(usr.HomeDir, ".testtrack")
-	TimestampFilePath := filepath.Join(TimestampDir, "build_timestamp.txt")
-
-	if _, err := os.Stat(TimestampDir); os.IsNotExist(err) {
-		err := os.Mkdir(TimestampDir, 0755)
-		if err != nil {
-			return err
-		}
-	}
-
 	timestamp := []byte(time.Now().Format("2006-01-02T15:04:05Z"))
-	err := ioutil.WriteFile(TimestampFilePath, timestamp, 0644)
+	err := ioutil.WriteFile("testtrack/build_timestamp.txt", timestamp, 0644)
 
 	return err
 }

--- a/cmds/generate_timestamp.go
+++ b/cmds/generate_timestamp.go
@@ -28,8 +28,7 @@ var generateTimestampCmd = &cobra.Command{
 }
 
 func generateTimestamp() error {
-	const buildTimestampPath = "testtrack/build_timestamp.txt"
 	timestamp := []byte(time.Now().UTC().Format("2006-01-02T15:04:05Z"))
 
-	return ioutil.WriteFile(buildTimestampPath, timestamp, 0644)
+	return ioutil.WriteFile("testtrack/build_timestamp.txt", timestamp, 0644)
 }

--- a/cmds/generate_timestamp.go
+++ b/cmds/generate_timestamp.go
@@ -22,7 +22,7 @@ func init() {
 
 var generateTimestampCmd = &cobra.Command{
 	Use:   "generate_timestamp",
-	Short: "Write the current timstamp to '~/.testtrack/build_timestamp.txt'",
+	Short: "Write the current timestamp to '~/.testtrack/build_timestamp.txt'",
 	Long:  generateTimestampDoc,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmds/generate_timestamp.go
+++ b/cmds/generate_timestamp.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"time"
 
@@ -30,8 +31,8 @@ var generateTimestampCmd = &cobra.Command{
 }
 
 func generateTimestamp() error {
-	homeDir, _ := os.UserHomeDir()
-	TimestampDir := filepath.Join(homeDir, ".testtrack")
+	usr, _ := user.Current()
+	TimestampDir := filepath.Join(usr.HomeDir, ".testtrack")
 	TimestampFilePath := filepath.Join(TimestampDir, "build_timestamp.txt")
 
 	if _, err := os.Stat(TimestampDir); os.IsNotExist(err) {

--- a/cmds/generate_timestamp.go
+++ b/cmds/generate_timestamp.go
@@ -8,9 +8,9 @@ import (
 )
 
 var generateTimestampDoc = `
-Write the current timestamp to the file 'build_timestamp.txt' in a TestTrack project.
-This timestamp can be passed as a param by the TestTrack client when calling the
-split registry endpoint from the TestTrack server.
+Write the current timestamp to the file 'testtrack/build_timestamp.txt' in a
+TestTrack project. This timestamp can be passed as a param by the TestTrack
+client when calling the split registry endpoint from the TestTrack server.
 `
 
 func init() {

--- a/cmds/generate_timestamp.go
+++ b/cmds/generate_timestamp.go
@@ -44,9 +44,6 @@ func generateTimestamp() error {
 
 	timestamp := []byte(time.Now().Format("2006-01-02T15:04:05Z"))
 	err := ioutil.WriteFile(TimestampFilePath, timestamp, 0644)
-	if err != nil {
-		return err
-	}
 
 	return err
 }

--- a/cmds/generate_timestamp.go
+++ b/cmds/generate_timestamp.go
@@ -1,0 +1,52 @@
+package cmds
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var generateTimestampDoc = `
+Write the current timestamp to the file '~/.testtrack/build_timestamp.txt'.
+This timestamp can be used by the Testtrack client as a timestamp param when
+calling the split registry endpoint from the Testtrack server.
+`
+
+func init() {
+	rootCmd.AddCommand(generateTimestampCmd)
+}
+
+var generateTimestampCmd = &cobra.Command{
+	Use:   "generate_timestamp",
+	Short: "Write the current timstamp to '~/.testtrack/build_timestamp.txt'",
+	Long:  generateTimestampDoc,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return generateTimestamp()
+	},
+}
+
+func generateTimestamp() error {
+	homeDir, _ := os.UserHomeDir()
+	TimestampDir := path.Join(homeDir, ".testtrack")
+	TimestampFilePath := filepath.Join(TimestampDir, "build_timestamp.txt")
+
+	if _, err := os.Stat(TimestampDir); os.IsNotExist(err) {
+		err := os.Mkdir(TimestampDir, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	timestamp := []byte(time.Now().Format("2006-01-02T15:04:05Z"))
+	err := ioutil.WriteFile(TimestampFilePath, timestamp, 0644)
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/cmds/generate_timestamp.go
+++ b/cmds/generate_timestamp.go
@@ -3,7 +3,6 @@ package cmds
 import (
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -12,8 +11,8 @@ import (
 
 var generateTimestampDoc = `
 Write the current timestamp to the file '~/.testtrack/build_timestamp.txt'.
-This timestamp can be used by the Testtrack client as a timestamp param when
-calling the split registry endpoint from the Testtrack server.
+This timestamp can be passed as a param by the Testtrack client when calling the
+split registry endpoint from the Testtrack server.
 `
 
 func init() {
@@ -32,7 +31,7 @@ var generateTimestampCmd = &cobra.Command{
 
 func generateTimestamp() error {
 	homeDir, _ := os.UserHomeDir()
-	TimestampDir := path.Join(homeDir, ".testtrack")
+	TimestampDir := filepath.Join(homeDir, ".testtrack")
 	TimestampFilePath := filepath.Join(TimestampDir, "build_timestamp.txt")
 
 	if _, err := os.Stat(TimestampDir); os.IsNotExist(err) {

--- a/cmds/generate_timestamp.go
+++ b/cmds/generate_timestamp.go
@@ -8,7 +8,7 @@ import (
 )
 
 var generateTimestampDoc = `
-Write the current UTC timestamp to the file 'testtrack/build_timestamp.txt'.
+Write the current UTC timestamp to the file 'testtrack/build_timestamp'.
 This timestamp is used by TestTrack clients to request the version of the split
 registry active at the given time.
 `
@@ -19,7 +19,7 @@ func init() {
 
 var generateTimestampCmd = &cobra.Command{
 	Use:   "generate_timestamp",
-	Short: "Write the current UTC timestamp to 'testtrack/build_timestamp.txt'",
+	Short: "Write the current UTC timestamp to 'testtrack/build_timestamp'",
 	Long:  generateTimestampDoc,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -30,5 +30,5 @@ var generateTimestampCmd = &cobra.Command{
 func generateTimestamp() error {
 	timestamp := []byte(time.Now().UTC().Format("2006-01-02T15:04:05Z"))
 
-	return ioutil.WriteFile("testtrack/build_timestamp.txt", timestamp, 0644)
+	return ioutil.WriteFile("testtrack/build_timestamp", timestamp, 0644)
 }


### PR DESCRIPTION
/domain @Betterment/test_track_core
/platform @devinburnette @drewblas @jmileham @samandmoore @kelvin-acosta 

This PR adds the generate_timestamp command to the CLI. generate_timestamp will write a UTC timestamp in a TestTrack project. That timestamp can then be used by the TestTrack client as a parameter when calling for split registries as it existed at a certain point in time.