### PR TITLE
Add new fake endpoint for split registry

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,33 @@
 
 
 [[projects]]
+  digest = "1:6e1bcd05ad9b028fbc1ee7f5c57732423b1721dc1fa6c9f28d739277a78d6e8d"
+  name = "github.com/Betterment/testtrack-cli"
+  packages = [
+    "cmds",
+    "fakeassignments",
+    "fakeserver",
+    "featurecompletions",
+    "identifiertypes",
+    "migrationloaders",
+    "migrationmanagers",
+    "migrationrunners",
+    "migrations",
+    "remotekills",
+    "schema",
+    "schemaloaders",
+    "serializers",
+    "servers",
+    "splitdecisions",
+    "splitretirements",
+    "splits",
+    "validations",
+  ]
+  pruneopts = ""
+  revision = "4cc560ae696392f72caf3c9843136628b80bf688"
+  version = "v1.0.2"
+
+[[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -128,6 +155,24 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/Betterment/testtrack-cli/cmds",
+    "github.com/Betterment/testtrack-cli/fakeassignments",
+    "github.com/Betterment/testtrack-cli/fakeserver",
+    "github.com/Betterment/testtrack-cli/featurecompletions",
+    "github.com/Betterment/testtrack-cli/identifiertypes",
+    "github.com/Betterment/testtrack-cli/migrationloaders",
+    "github.com/Betterment/testtrack-cli/migrationmanagers",
+    "github.com/Betterment/testtrack-cli/migrationrunners",
+    "github.com/Betterment/testtrack-cli/migrations",
+    "github.com/Betterment/testtrack-cli/remotekills",
+    "github.com/Betterment/testtrack-cli/schema",
+    "github.com/Betterment/testtrack-cli/schemaloaders",
+    "github.com/Betterment/testtrack-cli/serializers",
+    "github.com/Betterment/testtrack-cli/servers",
+    "github.com/Betterment/testtrack-cli/splitdecisions",
+    "github.com/Betterment/testtrack-cli/splitretirements",
+    "github.com/Betterment/testtrack-cli/splits",
+    "github.com/Betterment/testtrack-cli/validations",
     "github.com/gorilla/mux",
     "github.com/joho/godotenv",
     "github.com/pkg/errors",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,33 +2,6 @@
 
 
 [[projects]]
-  digest = "1:6e1bcd05ad9b028fbc1ee7f5c57732423b1721dc1fa6c9f28d739277a78d6e8d"
-  name = "github.com/Betterment/testtrack-cli"
-  packages = [
-    "cmds",
-    "fakeassignments",
-    "fakeserver",
-    "featurecompletions",
-    "identifiertypes",
-    "migrationloaders",
-    "migrationmanagers",
-    "migrationrunners",
-    "migrations",
-    "remotekills",
-    "schema",
-    "schemaloaders",
-    "serializers",
-    "servers",
-    "splitdecisions",
-    "splitretirements",
-    "splits",
-    "validations",
-  ]
-  pruneopts = ""
-  revision = "4cc560ae696392f72caf3c9843136628b80bf688"
-  version = "v1.0.2"
-
-[[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -155,24 +128,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/Betterment/testtrack-cli/cmds",
-    "github.com/Betterment/testtrack-cli/fakeassignments",
-    "github.com/Betterment/testtrack-cli/fakeserver",
-    "github.com/Betterment/testtrack-cli/featurecompletions",
-    "github.com/Betterment/testtrack-cli/identifiertypes",
-    "github.com/Betterment/testtrack-cli/migrationloaders",
-    "github.com/Betterment/testtrack-cli/migrationmanagers",
-    "github.com/Betterment/testtrack-cli/migrationrunners",
-    "github.com/Betterment/testtrack-cli/migrations",
-    "github.com/Betterment/testtrack-cli/remotekills",
-    "github.com/Betterment/testtrack-cli/schema",
-    "github.com/Betterment/testtrack-cli/schemaloaders",
-    "github.com/Betterment/testtrack-cli/serializers",
-    "github.com/Betterment/testtrack-cli/servers",
-    "github.com/Betterment/testtrack-cli/splitdecisions",
-    "github.com/Betterment/testtrack-cli/splitretirements",
-    "github.com/Betterment/testtrack-cli/splits",
-    "github.com/Betterment/testtrack-cli/validations",
     "github.com/gorilla/mux",
     "github.com/joho/godotenv",
     "github.com/pkg/errors",

--- a/fakeserver/routes.go
+++ b/fakeserver/routes.go
@@ -128,6 +128,11 @@ func (s *server) routes() {
 		"/api/v1/split_details/{id}",
 		getV1SplitDetail,
 	)
+
+	s.handleGet(
+		"/api/v3/builds/{timeStamp}/split_registry",
+		getV2SplitRegistry,
+	)
 }
 
 func getV1SplitRegistry() (interface{}, error) {

--- a/fakeserver/routes.go
+++ b/fakeserver/routes.go
@@ -86,7 +86,7 @@ func (s *server) routes() {
 	)
 	s.handleGet(
 		"/api/v2/split_registry",
-		getV2SplitRegistry,
+		getV2PlusSplitRegistry,
 	)
 	s.handlePostReturnNoContent(
 		"/api/v1/assignment_event",
@@ -128,10 +128,9 @@ func (s *server) routes() {
 		"/api/v1/split_details/{id}",
 		getV1SplitDetail,
 	)
-
 	s.handleGet(
 		"/api/v3/builds/{b}/split_registry",
-		getV2SplitRegistry,
+		getV2PlusSplitRegistry,
 	)
 }
 
@@ -150,7 +149,7 @@ func getV1SplitRegistry() (interface{}, error) {
 	return splitRegistry, nil
 }
 
-func getV2SplitRegistry() (interface{}, error) {
+func getV2PlusSplitRegistry() (interface{}, error) {
 	schema, err := schema.ReadMerged()
 	if err != nil {
 		return nil, err
@@ -276,7 +275,7 @@ func getV1AppVisitorConfig() (interface{}, error) {
 }
 
 func getV2AppVisitorConfig() (interface{}, error) {
-	isplitRegistry, err := getV2SplitRegistry()
+	isplitRegistry, err := getV2PlusSplitRegistry()
 	splitRegistry := isplitRegistry.(v2SplitRegistry)
 	if err != nil {
 		return nil, err

--- a/fakeserver/routes.go
+++ b/fakeserver/routes.go
@@ -130,7 +130,7 @@ func (s *server) routes() {
 	)
 
 	s.handleGet(
-		"/api/v3/builds/{timeStamp}/split_registry",
+		"/api/v3/builds/{b}/split_registry",
 		getV2SplitRegistry,
 	)
 }


### PR DESCRIPTION
This change adds a new fake endpoint for the testtrack cli `/api/v3/builds/{b}/split_registry`, which returns the V2 split registry. Was unable to locally confirm the change which may be due to issues with my local environment, would welcome someone else to sanity check that this change is correct.