### PR TITLE
Create testtrack directory when generating build timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=1.1.0
+VERSION=1.1.1
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/cmds/generate_build_timestamp.go
+++ b/cmds/generate_build_timestamp.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -29,6 +30,11 @@ var generateBuildTimestampCmd = &cobra.Command{
 
 func generateBuildTimestamp() error {
 	timestamp := []byte(time.Now().UTC().Format("2006-01-02T15:04:05Z"))
+
+	err := os.MkdirAll("testtrack", 0755)
+	if err != nil {
+		return err
+	}
 
 	return ioutil.WriteFile("testtrack/build_timestamp", timestamp, 0644)
 }


### PR DESCRIPTION
/domain @Betterment/test_track_core @phantomphildius @reggieag 
/no-platform

For apps which don't manage their own test track schema, the `testtrack` directory won't exist, causing the generate build timestamp command to fail.

We went with this approach rather than requiring apps to create an empty directory because some apps will never need that directory, so having it be required felt like project noise for what is a build/deploy-time concern.