### PR TITLE
Write a gitignore when initializing a project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=1.1.1
+VERSION=1.1.2
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/cmds/init_project.go
+++ b/cmds/init_project.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -38,6 +39,10 @@ func initProject() error {
 		log.Fatal(err)
 	}
 	keepfile.Close()
+
+	if err := ioutil.WriteFile("testtrack/.gitignore", []byte("build_timestamp\n"), 0644); err != nil {
+		log.Fatal(err)
+	}
 
 	_, err = schema.Generate()
 	return err


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform
/cc @phantomphildius 

When a project is built, `generate_build_timestamp` drops a `build_timestamp` file in the `testtrack` directory. The file is not meant to be committed, so generating a `.gitignore` file when we initialize a new project provides a nice default experience.