### PR TITLE
add support for v2 assignment overrides endpoint in fake server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=1.1.2
+VERSION=1.1.3
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/fakeserver/routes.go
+++ b/fakeserver/routes.go
@@ -26,6 +26,11 @@ type v1Assignment struct {
 	Unsynced  bool   `json:"unsynced"`
 }
 
+// v2AssignmentOverrideRequestBody is the JSON input for the V2 assignment override endpoint
+type v2AssignmentOverrideRequestBody struct {
+	Assignments []v1Assignment `json:"assignments"`
+}
+
 // v1VisitorConfig is the JSON output type for V1 visitor_config endpoints
 type v1VisitorConfig struct {
 	Splits  map[string]*splits.Weights `json:"splits"`
@@ -270,12 +275,12 @@ func postV2AssignmentOverride(r *http.Request) error {
 		if err != nil {
 			return err
 		}
-		var assignmentMap map[string][]v1Assignment
-		err = json.Unmarshal(requestBytes, &assignmentMap)
+		var assignmentBody v2AssignmentOverrideRequestBody
+		err = json.Unmarshal(requestBytes, &assignmentBody)
 		if err != nil {
 			return err
 		}
-		assignments = assignmentMap["assignments"]
+		assignments = assignmentBody.Assignments
 	default:
 		return fmt.Errorf("got unexpected content type %s", contentType)
 	}


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform

This PR adds support for the newly added v2 assignment override endpoint. https://github.com/Betterment/test_track/pull/145

I removed support for form url encoded POSTs for this new version of the endpoint. I did this partly because it simplified things and partly because I wasn't entirely sure how we'd wanna handle a POST request with a list of objects. I don't think it's all that valuable given the new request body format. 