### PR TITLE
feat(darwin-arm64): add support for darwin-arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.5'
+      - run: make test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: go
-
-go:
-  - 1.15.x
-
-script:
-  - make test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # testtrack-cli
 
-[![Build Status](https://travis-ci.org/Betterment/testtrack-cli.svg?branch=main)](https://travis-ci.org/Betterment/testtrack-cli)
+[![Build status](https://github.com/Betterment/testtrack-cli/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Betterment/testtrack-cli/actions/workflows/ci.yml?query=branch%3Amain)
 
 ## TestTrack Split Config Management
 

--- a/cmds/root.go
+++ b/cmds/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"runtime"
 
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
@@ -12,6 +13,7 @@ import (
 
 var version string
 var build string
+var arch string = fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 var noPrefix bool
 var force bool
 
@@ -26,7 +28,7 @@ func init() {
 var rootCmd = &cobra.Command{
 	Use:     "testtrack",
 	Short:   "TestTrack Split Config Management",
-	Long:    fmt.Sprintf("CLI for managing TestTrack experiments and feature gates\n\nVersion: %s\nBuild: %s", version, build),
+	Long:    fmt.Sprintf("CLI for managing TestTrack experiments and feature gates\n\nVersion: %s\nBuild: %s\nArch: %s", version, build, arch),
 	Version: version,
 }
 

--- a/fakeserver/server_test.go
+++ b/fakeserver/server_test.go
@@ -120,10 +120,26 @@ func TestSplitRegistry(t *testing.T) {
 		require.Nil(t, err)
 
 		require.Equal(t, 1, registry.ExperienceSamplingWeight)
-		require.Equal(t, "test.test_experiment", registry.Splits[0].Name)
-		require.Equal(t, 60, registry.Splits[0].Variants[0].Weight)
-		require.Equal(t, 40, registry.Splits[0].Variants[1].Weight)
-		require.Equal(t, false, registry.Splits[0].FeatureGate)
+
+		var split v4Split
+		for _, s := range registry.Splits {
+			if s.Name == "test.test_experiment" {
+				split = s
+			}
+		}
+		var control, treatment v4Variant
+		for _, v := range split.Variants {
+			if v.Name == "control" {
+				control = v
+			}
+			if v.Name == "treatment" {
+				treatment = v
+			}
+		}
+		require.Equal(t, "test.test_experiment", split.Name)
+		require.Equal(t, 60, control.Weight)
+		require.Equal(t, 40, treatment.Weight)
+		require.Equal(t, false, split.FeatureGate)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,20 @@
 module github.com/Betterment/testtrack-cli
 
-go 1.15
+go 1.17
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gorilla/mux v1.7.1
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/pkg/errors v0.8.1
 	github.com/rs/cors v1.6.0
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v2 v2.2.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
 )


### PR DESCRIPTION
* adds support in releases for darwin-arm64
* renames testtrack.darwin to testtrack.darwin-amd64
* adds testtrack.darwin-arm64
* upgrades go to 1.17 from 1.15
* sets up github actions for CI instead of travis

/domain @kelvin-acosta @jmileham @smudge @effron @devinburnette 
/no-platform

This isn't strictly necessary because the current Darwin artifacts run fine through rosetta2, but we don't want to rely on rosetta2 forever 😄 