### PR TITLE
Include example of `--weights` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ The `testtrack` CLI has the following features:
 
 ## Getting started
 
-1. Download/install testtrack CLI
+#### 1. Download/install testtrack CLI
 
 Currently TestTrack binaries for linux and macOS are distributed via [GitHub releases](https://github.com/Betterment/testtrack-cli/releases). We'll add a homebrew tap soon to assist in installing and daemonizing the server on macOS.
 
-2. Initialize your project
+#### 2. Initialize your project
 
 From your app root directory run:
 
@@ -30,7 +30,7 @@ This will create a `testtrack` subdirectory in your app that will store migratio
 
 It will also create a `~/.testtrack` directory that will hold your local server's assignment overrides (`assignments.yml`).
 
-3. Set up your app name in .env
+#### 3. Set up your app name in .env
 
 ```bash
 # [my_app_root]/.env
@@ -39,36 +39,44 @@ TESTTRACK_APP_NAME=my_app
 
 This is the name that your app will use to authenticate with TestTrack server in production (and any other environments you support). Typically in a unirepo, this can be your app repo name.
 
-4. Point your app's TestTrack client at the testtrack fake server for development
+#### 4. Point your app's TestTrack client at the testtrack fake server for development
 
 You'll be embedding the same app name as you used above into the URL, e.g. `http://my_app@localhost:8297`
 
-5. Configure your application bootstrap scripts
+#### 5. Configure your application bootstrap scripts
 
 You'll want to install the platform-appropriate `testtrack` binary and call `testtrack schema link --force` on each developer's machine.
 We recommend [Scripts To Rule Them All](https://github.com/github/scripts-to-rule-them-all) as a pattern for bootstrapping app development environments for your team.
 
-6. Wire up testtrack to your build/deploy pipeline
+#### 6. Wire up testtrack to your build/deploy pipeline
 
-  a. Set an ENV var named `TESTTRACK_CLI_URL` with your TestTrack app credentials, e.g.:
+a. Set an ENV var named `TESTTRACK_CLI_URL` with your TestTrack app credentials, e.g.:
 
-  ```bash
-  TESTTRACK_CLI_URL=https://my_app:my_super_secret_app_token@testtrack.mydomain.com
-  ```
+```bash
+TESTTRACK_CLI_URL=https://my_app:my_super_secret_app_token@testtrack.mydomain.com
+```
 
-  into your build/deploy pipeline via whatever secrets management solution you use (heroku secrets, [sops](https://github.com/mozilla/sops), etc).
+into your build/deploy pipeline via whatever secrets management solution you use (heroku secrets, [sops](https://github.com/mozilla/sops), etc).
 
-  b. Make sure the platform-appropriate `testtrack` binary is installed in your build/deploy environment (e.g. Jenkins, GoCD)
+b. Make sure the platform-appropriate `testtrack` binary is installed in your build/deploy environment (e.g. Jenkins, GoCD)
 
-  c. Run `testtrack migrate` from your app root. For server-side apps, this is great to wire up to the same build pipeline phase where you'd apply database migrations for your app. For mobile or other client-side apps, you'll want to run it after tests have passed and before persisting your gold master build artifact.
+c. Run `testtrack migrate` from your app root. For server-side apps, this is great to wire up to the same build pipeline phase where you'd apply database migrations for your app. For mobile or other client-side apps, you'll want to run it after tests have passed and before persisting your gold master build artifact.
 
-7. Start creating splits!
+#### 7. Start creating splits!
+
+By default, splits will default to 100% false:
 
 ```bash
 testtrack create feature_gate my_new_feature_q2_2019_enabled
 ```
 
-8. Retire splits
+Use the `--weights` argument to specify custom variants and weights:
+
+```
+testtrack create experiment my_new_feature_q2_2019_experiment --weights "control: 50, treatment_a: 25, treatment_b: 25"
+```
+
+#### 8. Retire splits
 
 Once an experiment is finished or feature released, remove all references to split in code. Then, decide and retire split.
 


### PR DESCRIPTION
/domain @samandmoore @jmileham @jesseproudman 
/no-platform

I'm also adjusting the formatting of the README to put the "getting started" steps under H4 tags - felt easier to parse at a glance.

The only addition here is under step 8:

> Use the `--weights` argument to specify custom variants and weights:
> 
> ```
> testtrack create experiment my_new_feature_q2_2019_experiment --weights "control: 50, treatment_a: 25, treatment_b: 25"
> ```