### PR TITLE
Permit required ownership of flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=1.4.0
+VERSION=1.5.0
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \
@@ -38,7 +38,7 @@ test:
 			then\
 				echo "Style violations found. Run the following command to fix:";\
 				echo;\
-				echo "goimports -w" $$GOIMPORTS_RESULT;\
+				echo "$$(go env GOPATH)/bin/goimports -w" $$GOIMPORTS_RESULT;\
 				echo;\
 				exit 1;\
 			fi

--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ Run `testtrack help` for more documentation on how to configure splits and other
 
 Happy TestTracking!
 
+## Additional Configuration
+
+The following configuration options are available:
+
+### Split ownership
+If you have a large organization, you may wish to tag ownership of splits to a specific team to help provide accountability for clean up. This is supported natively in test_track.
+
+1. You must specify an ownership file. The default file exists at `testtrack/owners.yml` though that can be overwritten with the TESTTRACK_OWNERSHIP_FILE environment variable.
+2. This file should contain a list of team names, one per line. Any sub-values of the key names will be ignored for the purposes of test track.
+3. If the test track client is able to find this file, it will require an `--owner` flag be set when creating new splits and experiements.
+4. This data will be passed to the test track server where it can be recorded on the split records
+
+
+
 ## How to Contribute
 
 We would love for you to contribute! Anything that benefits the majority of TestTrack users—from a documentation fix to an entirely new feature—is encouraged.

--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ If you have a large organization, you may wish to tag ownership of splits to a s
 3. If the test track client is able to find this file, it will require an `--owner` flag be set when creating new splits and experiements.
 4. This data will be passed to the test track server where it can be recorded on the split records
 
-
-
 ## How to Contribute
 
 We would love for you to contribute! Anything that benefits the majority of TestTrack users—from a documentation fix to an entirely new feature—is encouraged.

--- a/cmds/create_experiment.go
+++ b/cmds/create_experiment.go
@@ -29,8 +29,7 @@ destroyed split if it was destroyed by mistake, but the migration will fail if
 you attempt to create a new split without a prefix.
 `
 
-var createExperimentWeights string
-var createExperimentOwner string
+var createExperimentWeights, createExperimentOwner string
 
 func init() {
 	createExperimentCmd.Flags().StringVar(&createExperimentOwner, "owner", "", "Who owns this feature flag?")

--- a/cmds/create_experiment.go
+++ b/cmds/create_experiment.go
@@ -64,7 +64,7 @@ func createExperiment(name, weights string, owner string) error {
 		return err
 	}
 
-	err = validations.ValidateOwnerName(owner, ownershipFilename)
+	err = validations.ValidateOwnerName(owner)
 	if err != nil {
 		return err
 	}

--- a/cmds/create_experiment.go
+++ b/cmds/create_experiment.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 var createExperimentCmd = &cobra.Command{
-	Use:   "experiment name --owner <OWNER>",
+	Use:   "experiment name",
 	Short: "Create or update an experiment's configuration",
 	Long:  createExperimentDoc,
 	Args:  cobra.ExactArgs(1),

--- a/cmds/create_feature_gate.go
+++ b/cmds/create_feature_gate.go
@@ -33,8 +33,7 @@ destroyed split if it was destroyed by mistake, but the migration will fail if
 you attempt to create a new split without a prefix.
 `
 
-var createFeatureGateDefault, createFeatureGateWeights string
-var createFeatureGateOwner string
+var createFeatureGateDefault, createFeatureGateWeights, createFeatureGateOwner string
 
 func init() {
 	createFeatureGateCmd.Flags().StringVar(&createFeatureGateOwner, "owner", "", "Who owns this feature flag?")

--- a/cmds/create_feature_gate.go
+++ b/cmds/create_feature_gate.go
@@ -15,7 +15,7 @@ Creates or updates a feature gate split.
 
 Example:
 
-testtrack create feature_gate my_feature_enabled --owner <OWNER>
+testtrack create feature_gate my_feature_enabled
 
 Feature gates will default to having two variants: true and false, and having a
 weighting of 100% false.
@@ -45,7 +45,7 @@ func init() {
 }
 
 var createFeatureGateCmd = &cobra.Command{
-	Use:   "feature_gate name --owner <OWNER>",
+	Use:   "feature_gate name",
 	Short: "Create or update a feature_gate's configuration",
 	Long:  createFeatureGateDoc,
 	Args:  cobra.ExactArgs(1),

--- a/cmds/create_feature_gate.go
+++ b/cmds/create_feature_gate.go
@@ -15,7 +15,7 @@ Creates or updates a feature gate split.
 
 Example:
 
-testtrack create feature_gate my_feature_enabled
+testtrack create feature_gate my_feature_enabled --owner <OWNER>
 
 Feature gates will default to having two variants: true and false, and having a
 weighting of 100% false.
@@ -34,8 +34,10 @@ you attempt to create a new split without a prefix.
 `
 
 var createFeatureGateDefault, createFeatureGateWeights string
+var createFeatureGateOwner string
 
 func init() {
+	createFeatureGateCmd.Flags().StringVar(&createFeatureGateOwner, "owner", "", "Who owns this feature flag?")
 	createFeatureGateCmd.Flags().StringVar(&createFeatureGateDefault, "default", "false", "Default variant for your feature flag")
 	createFeatureGateCmd.Flags().StringVar(&createFeatureGateWeights, "weights", "", "Variant weights to use (overrides default)")
 	createFeatureGateCmd.Flags().BoolVar(&noPrefix, "no-prefix", false, "Don't prefix feature gate with app_name (supports existing legacy splits)")
@@ -43,16 +45,16 @@ func init() {
 }
 
 var createFeatureGateCmd = &cobra.Command{
-	Use:   "feature_gate name",
+	Use:   "feature_gate name --owner <OWNER>",
 	Short: "Create or update a feature_gate's configuration",
 	Long:  createFeatureGateDoc,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return createFeatureGate(args[0], createFeatureGateDefault, createFeatureGateWeights)
+		return createFeatureGate(args[0], createFeatureGateDefault, createFeatureGateWeights, createFeatureGateOwner)
 	},
 }
 
-func createFeatureGate(name, defaultVariant, weights string) error {
+func createFeatureGate(name, defaultVariant, weights string, owner string) error {
 	schema, err := schema.Read()
 	if err != nil {
 		return err
@@ -74,6 +76,11 @@ func createFeatureGate(name, defaultVariant, weights string) error {
 		if !noPrefix {
 			name = fmt.Sprintf("%s.%s", appName, name)
 		}
+	}
+
+	err = validations.ValidateOwnerName(owner, ownershipFilename)
+	if err != nil {
+		return err
 	}
 
 	if len(weights) == 0 {
@@ -104,7 +111,7 @@ func createFeatureGate(name, defaultVariant, weights string) error {
 		return fmt.Errorf("weights %v are missing false variant", *weightsMap)
 	}
 
-	split, err := splits.New(&name, weightsMap)
+	split, err := splits.New(&name, weightsMap, &createFeatureGateOwner)
 	if err != nil {
 		return err
 	}

--- a/cmds/create_feature_gate.go
+++ b/cmds/create_feature_gate.go
@@ -77,7 +77,7 @@ func createFeatureGate(name, defaultVariant, weights string, owner string) error
 		}
 	}
 
-	err = validations.ValidateOwnerName(owner, ownershipFilename)
+	err = validations.ValidateOwnerName(owner)
 	if err != nil {
 		return err
 	}

--- a/cmds/root.go
+++ b/cmds/root.go
@@ -19,13 +19,7 @@ var force bool
 var ownershipFilename string
 
 func init() {
-	ownershipFilename = os.Getenv("TESTTRACK_OWNERSHIP_FILE")
-
-	_, urlSet := os.LookupEnv("TESTTRACK_CLI_URL")
-	_, appNameSet := os.LookupEnv("TESTTRACK_APP_NAME")
-	if !urlSet && !appNameSet {
-		godotenv.Load()
-	}
+	godotenv.Load()
 }
 
 var rootCmd = &cobra.Command{

--- a/cmds/root.go
+++ b/cmds/root.go
@@ -16,8 +16,11 @@ var build string
 var arch string = fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
 var noPrefix bool
 var force bool
+var ownershipFilename string
 
 func init() {
+	ownershipFilename = os.Getenv("TESTTRACK_OWNERSHIP_FILE")
+
 	_, urlSet := os.LookupEnv("TESTTRACK_CLI_URL")
 	_, appNameSet := os.LookupEnv("TESTTRACK_APP_NAME")
 	if !urlSet && !appNameSet {

--- a/serializers/serializers.go
+++ b/serializers/serializers.go
@@ -73,7 +73,7 @@ type SchemaSplit struct {
 	Name    string        `yaml:"name"`
 	Weights yaml.MapSlice `yaml:"weights"`
 	Decided bool          `yaml:"decided,omitempty"`
-	Owner   string        `yaml:"squad,omitempty"`
+	Owner   string        `yaml:"owner,omitempty"`
 }
 
 // Schema is the YAML-marshalable representation of the TestTrack schema for

--- a/serializers/serializers.go
+++ b/serializers/serializers.go
@@ -42,7 +42,7 @@ type RemoteKill struct {
 type SplitYAML struct {
 	Name    string        `yaml:"name"`
 	Weights yaml.MapSlice `yaml:"weights"`
-	Squad   string        `yaml:"owner,omitempty"`
+	Owner   string        `yaml:"owner,omitempty"`
 }
 
 // SplitJSON is is the JSON-marshalabe representation of a Split
@@ -73,7 +73,7 @@ type SchemaSplit struct {
 	Name    string        `yaml:"name"`
 	Weights yaml.MapSlice `yaml:"weights"`
 	Decided bool          `yaml:"decided,omitempty"`
-	Squad   string        `yaml:"squad,omitempty"`
+	Owner   string        `yaml:"squad,omitempty"`
 }
 
 // Schema is the YAML-marshalable representation of the TestTrack schema for

--- a/serializers/serializers.go
+++ b/serializers/serializers.go
@@ -42,6 +42,7 @@ type RemoteKill struct {
 type SplitYAML struct {
 	Name    string        `yaml:"name"`
 	Weights yaml.MapSlice `yaml:"weights"`
+	Squad   string        `yaml:"owner,omitempty"`
 }
 
 // SplitJSON is is the JSON-marshalabe representation of a Split
@@ -72,6 +73,7 @@ type SchemaSplit struct {
 	Name    string        `yaml:"name"`
 	Weights yaml.MapSlice `yaml:"weights"`
 	Decided bool          `yaml:"decided,omitempty"`
+	Squad   string        `yaml:"squad,omitempty"`
 }
 
 // Schema is the YAML-marshalable representation of the TestTrack schema for

--- a/splits/splits.go
+++ b/splits/splits.go
@@ -25,11 +25,11 @@ type Split struct {
 	migrationVersion *string
 	name             *string
 	weights          *Weights
-	squad            *string
+	owner            *string
 }
 
 // New returns a migration object
-func New(name *string, weights *Weights, squad *string) (migrations.IMigration, error) {
+func New(name *string, weights *Weights, owner *string) (migrations.IMigration, error) {
 	migrationVersion, err := migrations.GenerateMigrationVersion()
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func New(name *string, weights *Weights, squad *string) (migrations.IMigration, 
 		migrationVersion: migrationVersion,
 		name:             name,
 		weights:          weights,
-		squad:            squad,
+		owner:            owner,
 	}, nil
 }
 
@@ -112,7 +112,7 @@ func (s *Split) File() *serializers.MigrationFile {
 		Split: &serializers.SplitYAML{
 			Name:    *s.name,
 			Weights: s.weights.ToYAML(),
-			Squad:   *s.squad,
+			Owner:   *s.owner,
 		},
 	}
 }
@@ -179,7 +179,7 @@ func (s *Split) ApplyToSchema(schema *serializers.Schema, migrationRepo migratio
 		Name:    *s.name,
 		Weights: s.weights.ToYAML(),
 		Decided: false,
-		Squad:   *s.squad,
+		Owner:   *s.owner,
 	}
 	schema.Splits = append(schema.Splits, schemaSplit)
 	return nil

--- a/splits/splits.go
+++ b/splits/splits.go
@@ -25,10 +25,11 @@ type Split struct {
 	migrationVersion *string
 	name             *string
 	weights          *Weights
+	squad            *string
 }
 
 // New returns a migration object
-func New(name *string, weights *Weights) (migrations.IMigration, error) {
+func New(name *string, weights *Weights, squad *string) (migrations.IMigration, error) {
 	migrationVersion, err := migrations.GenerateMigrationVersion()
 	if err != nil {
 		return nil, err
@@ -38,6 +39,7 @@ func New(name *string, weights *Weights) (migrations.IMigration, error) {
 		migrationVersion: migrationVersion,
 		name:             name,
 		weights:          weights,
+		squad:            squad,
 	}, nil
 }
 
@@ -110,6 +112,7 @@ func (s *Split) File() *serializers.MigrationFile {
 		Split: &serializers.SplitYAML{
 			Name:    *s.name,
 			Weights: s.weights.ToYAML(),
+			Squad:   *s.squad,
 		},
 	}
 }
@@ -176,6 +179,7 @@ func (s *Split) ApplyToSchema(schema *serializers.Schema, migrationRepo migratio
 		Name:    *s.name,
 		Weights: s.weights.ToYAML(),
 		Decided: false,
+		Squad:   *s.squad,
 	}
 	schema.Splits = append(schema.Splits, schemaSplit)
 	return nil

--- a/validations/validations.go
+++ b/validations/validations.go
@@ -70,7 +70,7 @@ func AutoPrefixAndValidateSplit(paramName string, value *string, currentAppName 
 	return SplitExistsInSchema(paramName, value, schema)
 }
 
-// ValidateOwnerName ensures that if a .squads.yml file is present, the owner matches
+// ValidateOwnerName ensures that if a testtrack/owners.yml file is present, the owner matches
 // the list of owners in that file.
 func ValidateOwnerName(owner string, ownershipFilename string) error {
 	if ownershipFilename == "" {

--- a/validations/validations.go
+++ b/validations/validations.go
@@ -97,13 +97,13 @@ func ValidateOwnerName(owner string, ownershipFilename string) error {
 		return err
 	}
 
-	ownersArray := make(map[string]*struct{})
-	err = yaml.Unmarshal(fileBytes, ownersArray)
+	ownersMap := make(map[string]*struct{})
+	err = yaml.Unmarshal(fileBytes, ownersMap)
 	if err != nil {
 		return err
 	}
 
-	if !mapContainsValue(owner, ownersArray) {
+	if !mapContainsValue(owner, ownersMap) {
 		return fmt.Errorf("owner '%s' is not defined in ownership file (%s)", owner, ownershipFilename)
 	}
 

--- a/validations/validations_test.go
+++ b/validations/validations_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const defaultOwnershipFilename = "testtrack/owners.yml"
-
 func TestAutoPrefixAndValidateSplit(t *testing.T) {
 	t.Run("it blows up when noPrefix: true and input is prefixed", func(t *testing.T) {
 		paramName := "split_name"
@@ -136,30 +134,31 @@ func TestAutoPrefixAndValidateSplit(t *testing.T) {
 
 func TestValidateOwnerName(t *testing.T) {
 	t.Run("it succeeds with no owner if ownershipFilename is undefined and the default file does not exist", func(t *testing.T) {
-		err := validations.ValidateOwnerName("", "")
+		err := validations.ValidateOwnerName("")
 		require.NoError(t, err)
 	})
 
 	t.Run("it fails with an owner if ownershipFilename is undefined and the default file does not exist ", func(t *testing.T) {
-		err := validations.ValidateOwnerName("super_owner", "")
+		err := validations.ValidateOwnerName("super_owner")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "owner must be blank because ownership file (testtrack/owners.yml) could not be found")
 	})
 
 	t.Run("it fails if using default ownership file and owner is blank", func(t *testing.T) {
-		WriteOwnershipFile(defaultOwnershipFilename)
+		WriteOwnershipFile(validations.DefaultOwnershipFilePath)
 
-		err := validations.ValidateOwnerName("", "")
+		err := validations.ValidateOwnerName("")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "owner must be specified when ownership file (testtrack/owners.yml) exists")
 
-		RemoveOwnershipFile(defaultOwnershipFilename)
+		RemoveOwnershipFile(validations.DefaultOwnershipFilePath)
 	})
 
 	t.Run("it fails if using specified ownership file and owner is blank", func(t *testing.T) {
 		WriteOwnershipFile(".owners.yml")
+		t.Setenv("TESTTRACK_OWNERSHIP_FILE", ".owners.yml")
 
-		err := validations.ValidateOwnerName("", ".owners.yml")
+		err := validations.ValidateOwnerName("")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "owner must be specified when ownership file (.owners.yml) exists")
 
@@ -167,37 +166,39 @@ func TestValidateOwnerName(t *testing.T) {
 	})
 
 	t.Run("it succeeds if using default ownership file and owner exists", func(t *testing.T) {
-		WriteOwnershipFile(defaultOwnershipFilename)
+		WriteOwnershipFile(validations.DefaultOwnershipFilePath)
 
-		err := validations.ValidateOwnerName("super_owner", "")
+		err := validations.ValidateOwnerName("super_owner")
 		require.NoError(t, err)
 
-		RemoveOwnershipFile(defaultOwnershipFilename)
+		RemoveOwnershipFile(validations.DefaultOwnershipFilePath)
 	})
 
 	t.Run("it succeeds if using specified ownership file and owner exists", func(t *testing.T) {
 		WriteOwnershipFile(".owners.yml")
+		t.Setenv("TESTTRACK_OWNERSHIP_FILE", ".owners.yml")
 
-		err := validations.ValidateOwnerName("super_owner", ".owners.yml")
+		err := validations.ValidateOwnerName("super_owner")
 		require.NoError(t, err)
 
 		RemoveOwnershipFile(".owners.yml")
 	})
 
 	t.Run("it fails if using default ownership file and owner does not exist", func(t *testing.T) {
-		WriteOwnershipFile(defaultOwnershipFilename)
+		WriteOwnershipFile(validations.DefaultOwnershipFilePath)
 
-		err := validations.ValidateOwnerName("superb_owner", "")
+		err := validations.ValidateOwnerName("superb_owner")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "owner 'superb_owner' is not defined in ownership file (testtrack/owners.yml)")
 
-		RemoveOwnershipFile(defaultOwnershipFilename)
+		RemoveOwnershipFile(validations.DefaultOwnershipFilePath)
 	})
 
 	t.Run("it fails if using specified ownership file and owner does not exist", func(t *testing.T) {
 		WriteOwnershipFile(".owners.yml")
+		t.Setenv("TESTTRACK_OWNERSHIP_FILE", ".owners.yml")
 
-		err := validations.ValidateOwnerName("superb_owner", ".owners.yml")
+		err := validations.ValidateOwnerName("superb_owner")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "owner 'superb_owner' is not defined in ownership file (.owners.yml)")
 


### PR DESCRIPTION
Add support for tagging of ownership of a specific feature flag.

This works either through the presence of a default ownership file (`testtrack/owners.yml`) or a file specified via an ENV variable (`TESTTRACK_OWNERSHIP_FILE`).

If the file exists, `--owner` is required to be set and to match one of the owners in the file.

If the file does not exist, `--owner` is required to be blank.
