### PR TITLE
Allow localhost origins

### DIFF
--- a/fakeserver/server.go
+++ b/fakeserver/server.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -50,13 +51,19 @@ func createCors() *cors.Cors {
 					return true
 				}
 			}
-			if origin == "localhost" {
-				return true
+
+			if parsed, err := url.Parse(origin); err == nil {
+				hostname := parsed.Hostname()
+
+				if hostname == "localhost" {
+					return true
+				}
+
+				if ip := net.ParseIP(hostname); ip != nil && ip.IsLoopback() {
+					return true
+				}
 			}
-			ip := net.ParseIP(origin)
-			if ip != nil && ip.IsLoopback() {
-				return true
-			}
+
 			return false
 		},
 	})

--- a/fakeserver/server_test.go
+++ b/fakeserver/server_test.go
@@ -246,6 +246,32 @@ func TestCors(t *testing.T) {
 		require.Equal(t, "http://www.allowed.com", w.HeaderMap.Get("Access-Control-Allow-Origin"))
 	})
 
+	t.Run("it passes cors from localhost", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h := createHandler()
+
+		request := httptest.NewRequest("GET", "/api/v2/split_registry", nil)
+		request.Header.Add("Origin", "http://localhost:3000")
+
+		h.ServeHTTP(w, request)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "http://localhost:3000", w.HeaderMap.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("it passes cors from loopback ip", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		h := createHandler()
+
+		request := httptest.NewRequest("GET", "/api/v2/split_registry", nil)
+		request.Header.Add("Origin", "http://127.0.0.1:3000")
+
+		h.ServeHTTP(w, request)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "http://127.0.0.1:3000", w.HeaderMap.Get("Access-Control-Allow-Origin"))
+	})
+
 	os.Unsetenv("TESTTRACK_ALLOWED_ORIGINS")
 }
 


### PR DESCRIPTION
I was trying to use the Chrome extension on localhost. As I changed splits, they would fail to save and the page would reload. I managed to intercept the error by setting a breakpoint on the beforeunload event.

<img width="1485" alt="Screenshot 2025-04-11 at 8 28 00 PM" src="https://github.com/user-attachments/assets/f2824560-9cec-4755-9a91-4a3e7d7dbc97" />

After doing a little digging, it seems like our CORS allowlist isn't working correctly because the `origin` is a URI, not a hostname.

In order to avoid any breaking changes, I didn't change the `TESTTRACK_ALLOWED_ORIGINS` logic, but it seems like what we actually want is for those to apply to the hostname, rather than the URI.