### PR TITLE
feat: JSON schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=1.7.1
+VERSION=1.8.0
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you have a large organization, you may wish to tag ownership of splits to a s
 
 ### Syncing split assignments
 
-If you want to ensure that your local split assignments are in sync with your remote (production) assignments, you can run `TESTTRACK_CLI_URL=<base_url> testtrack sync` (e.g. `TESTTRACK_CLI_URL=https://tt.example.com testtrack sync`) from your project directory to pull the assignments from your remote server into your local `schema.yml` file.
+If you want to ensure that your local split assignments are in sync with your remote (production) assignments, you can run `TESTTRACK_CLI_URL=<base_url> testtrack sync` (e.g. `TESTTRACK_CLI_URL=https://tt.example.com testtrack sync`) from your project directory to pull the assignments from your remote server into your local `schema.{json,yml}` file.
 
 ## How to Contribute
 

--- a/cmds/schema_generate.go
+++ b/cmds/schema_generate.go
@@ -7,10 +7,10 @@ import (
 
 var schemaGenerateDoc = `
 Reads the migrations in testtrack/migrate and writes the resulting schema state
-to testtrack/schema.yml, overwriting the file if it already exists. Generate
+to testtrack/schema.{json,yml}, overwriting the file if it already exists. Generate
 makes no TestTrack API calls.
 
-In addition to refreshing a schema.yml file that may have been corrupted due to
+In addition to refreshing a schema file that may have been corrupted due to
 a bad merge or bug that produced incorrect schema state, 'schema generate' will
 also validate that migrations merged from multiple development branches don't
 logically conflict, or else it will fail with errors.
@@ -30,7 +30,7 @@ func init() {
 
 var schemaGenerateCmd = &cobra.Command{
 	Use:   "generate",
-	Short: "Generate schema.yml from migration files",
+	Short: "Generate schema.{json,yml} from migration files",
 	Long:  schemaGenerateDoc,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmds/schema_load.go
+++ b/cmds/schema_load.go
@@ -6,7 +6,7 @@ import (
 )
 
 var schemaLoadDoc = `
-Loads the testtrack/schema.yml state into TestTrack server. This operation is
+Loads the testtrack/schema.{json,yml} state into TestTrack server. This operation is
 idempotent with a valid, consistent schema file, though might fail if your
 schema file became invalid due to a bad merge or a bug.
 
@@ -27,7 +27,7 @@ func init() {
 
 var schemaLoadCmd = &cobra.Command{
 	Use:   "load",
-	Short: "Load schema.yml state into TestTrack server",
+	Short: "Load schema.{json,yml} state into TestTrack server",
 	Long:  schemaLoadDoc,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmds/server.go
+++ b/cmds/server.go
@@ -6,7 +6,7 @@ import (
 )
 
 var serverDoc = `
-Run a fake TestTrack server for local development, backed by schema.yml files
+Run a fake TestTrack server for local development, backed by schema.{json,yml} files
 and nonsense.
 `
 

--- a/cmds/sync.go
+++ b/cmds/sync.go
@@ -48,7 +48,7 @@ func Sync() error {
 		remoteSplit, exists := splitRegistry.Splits[localSplit.Name]
 		if exists {
 			remoteWeights := splits.Weights(remoteSplit.Weights)
-			localSchema.Splits[ind].Weights = remoteWeights.ToYAML()
+			localSchema.Splits[ind].Weights = remoteWeights
 		}
 	}
 

--- a/fakeserver/routes.go
+++ b/fakeserver/routes.go
@@ -192,7 +192,7 @@ func getV1SplitRegistry() (interface{}, error) {
 	}
 	splitRegistry := map[string]*splits.Weights{}
 	for _, split := range schema.Splits {
-		splitRegistry[split.Name], err = splits.WeightsFromYAML(split.Weights)
+		splitRegistry[split.Name], err = splits.NewWeights(split.Weights)
 		if err != nil {
 			return nil, err
 		}
@@ -208,7 +208,7 @@ func getV2PlusSplitRegistry() (interface{}, error) {
 	splitRegistry := map[string]*v2Split{}
 	for _, split := range schema.Splits {
 		isFeatureGate := splits.IsFeatureGateFromName(split.Name)
-		weights, err := splits.WeightsFromYAML(split.Weights)
+		weights, err := splits.NewWeights(split.Weights)
 		if err != nil {
 			return nil, err
 		}
@@ -231,7 +231,7 @@ func getV4SplitRegistry() (interface{}, error) {
 	v4Splits := make([]v4Split, 0, len(schema.Splits))
 	for _, split := range schema.Splits {
 		isFeatureGate := splits.IsFeatureGateFromName(split.Name)
-		weights, err := splits.WeightsFromYAML(split.Weights)
+		weights, err := splits.NewWeights(split.Weights)
 		if err != nil {
 			return nil, err
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -16,21 +16,21 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// Finds the path to the schema file (preferring JSON), or returns testtrack/schema.json and an error if neither exists
-func findSchemaPath() (string, error) {
+// Finds the path to the schema file (preferring JSON), or returns testtrack/schema.json
+func findSchemaPath() (string, bool) {
 	if _, err := os.Stat("testtrack/schema.json"); err == nil {
-		return "testtrack/schema.json", nil
+		return "testtrack/schema.json", true
 	}
 	if _, err := os.Stat("testtrack/schema.yml"); err == nil {
-		return "testtrack/schema.yml", nil
+		return "testtrack/schema.yml", true
 	}
-	return "testtrack/schema.json", errors.New("testtrack/schema.{json,yml} does not exist. Are you in your app root dir? If so, call testtrack init_project first")
+	return "testtrack/schema.json", false
 }
 
 // Read a schema from disk or generate one
 func Read() (*serializers.Schema, error) {
-	schemaPath, err := findSchemaPath()
-	if err != nil {
+	schemaPath, exists := findSchemaPath()
+	if !exists {
 		return Generate()
 	}
 	schemaBytes, err := os.ReadFile(schemaPath)
@@ -90,9 +90,9 @@ func Write(schema *serializers.Schema) error {
 
 // Link a schema to the user's home dir
 func Link(force bool) error {
-	schemaPath, err := findSchemaPath()
-	if err != nil {
-		return err
+	schemaPath, exists := findSchemaPath()
+	if !exists {
+		return errors.New("testtrack/schema.{json,yml} does not exist. Are you in your app root dir? If so, call testtrack init_project first")
 	}
 	dir, err := os.Getwd()
 	if err != nil {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -127,22 +127,14 @@ func ReadMerged() (*serializers.Schema, error) {
 	}
 	var mergedSchema serializers.Schema
 	for _, path := range paths {
-		// Deref symlink
-		fi, err := os.Lstat(path)
-		if err != nil {
-			return nil, err
-		}
-		if fi.Mode()&os.ModeSymlink != 0 {
-			path, err = os.Readlink(path)
-			if err != nil {
-				continue // It's OK if this symlink isn't traversable (e.g. app was uninstalled), we'll just skip it.
-			}
-		}
-		// Read file
 		schemaBytes, err := os.ReadFile(path)
 		if err != nil {
+			if os.IsNotExist(err) {
+				continue // It's OK if this file doesn't exist (e.g. broken symlink, app was uninstalled), we'll just skip it.
+			}
 			return nil, err
 		}
+
 		var schema serializers.Schema
 		err = yaml.Unmarshal(schemaBytes, &schema)
 		if err != nil {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -170,18 +170,18 @@ func mergeLegacySchema(schema *serializers.Schema) error {
 		if !ok {
 			return fmt.Errorf("expected split name, got %v", mapSlice.Key)
 		}
-		weightsYAML, ok := mapSlice.Value.(yaml.MapSlice)
+		weightsYAML, ok := mapSlice.Value.(map[string]int)
 		if !ok {
 			return fmt.Errorf("expected weights, got %v", mapSlice.Value)
 		}
-		weights, err := splits.WeightsFromYAML(weightsYAML)
+		weights, err := splits.NewWeights(weightsYAML)
 		if err != nil {
 			return err
 		}
 
 		schema.Splits = append(schema.Splits, serializers.SchemaSplit{
 			Name:    name,
-			Weights: weights.ToYAML(),
+			Weights: *weights,
 			Decided: false,
 		})
 	}

--- a/schemaloaders/schemaloaders.go
+++ b/schemaloaders/schemaloaders.go
@@ -98,7 +98,7 @@ func schemaSplitMigrations(schemaSplit serializers.SchemaSplit) ([]migrations.IM
 
 	if schemaSplit.Decided {
 		var decision *string
-		weights, err := splits.WeightsFromYAML(schemaSplit.Weights)
+		weights, err := splits.NewWeights(schemaSplit.Weights)
 		if err != nil {
 			return nil, fmt.Errorf("schema split %s invalid: %w", schemaSplit.Name, err)
 		}

--- a/serializers/serializers.go
+++ b/serializers/serializers.go
@@ -80,21 +80,21 @@ type IdentifierType struct {
 
 // SchemaSplit is the schema-file YAML-marshalable representation of a split's state
 type SchemaSplit struct {
-	Name    string         `yaml:"name"`
-	Weights map[string]int `yaml:"weights"`
-	Decided bool           `yaml:"decided,omitempty"`
-	Owner   string         `yaml:"owner,omitempty"`
+	Name    string         `yaml:"name" json:"name"`
+	Weights map[string]int `yaml:"weights" json:"weights"`
+	Decided bool           `yaml:"decided,omitempty" json:"decided,omitempty"`
+	Owner   string         `yaml:"owner,omitempty" json:"owner,omitempty"`
 }
 
 // Schema is the YAML-marshalable representation of the TestTrack schema for
 // migration validation and bootstrapping of new ecosystems
 type Schema struct {
-	SerializerVersion  int                 `yaml:"serializer_version"`
-	SchemaVersion      string              `yaml:"schema_version"`
-	Splits             []SchemaSplit       `yaml:"splits,omitempty"`
-	IdentifierTypes    []IdentifierType    `yaml:"identifier_types,omitempty"`
-	RemoteKills        []RemoteKill        `yaml:"remote_kills,omitempty"`
-	FeatureCompletions []FeatureCompletion `yaml:"feature_completions,omitempty"`
+	SerializerVersion  int                 `yaml:"serializer_version" json:"serializer_version"`
+	SchemaVersion      string              `yaml:"schema_version" json:"schema_version"`
+	Splits             []SchemaSplit       `yaml:"splits,omitempty" json:"splits,omitempty"`
+	IdentifierTypes    []IdentifierType    `yaml:"identifier_types,omitempty" json:"identifier_types,omitempty"`
+	RemoteKills        []RemoteKill        `yaml:"remote_kills,omitempty" json:"remote_kills,omitempty"`
+	FeatureCompletions []FeatureCompletion `yaml:"feature_completions,omitempty" json:"feature_completions,omitempty"`
 }
 
 // LegacySchema represents the Rails migration-piggybacked testtrack schema files of old

--- a/serializers/serializers.go
+++ b/serializers/serializers.go
@@ -40,9 +40,9 @@ type RemoteKill struct {
 
 // SplitYAML is the YAML-marshalable representation of a Split
 type SplitYAML struct {
-	Name    string        `yaml:"name"`
-	Weights yaml.MapSlice `yaml:"weights"`
-	Owner   string        `yaml:"owner,omitempty"`
+	Name    string         `yaml:"name"`
+	Weights map[string]int `yaml:"weights"`
+	Owner   string         `yaml:"owner,omitempty"`
 }
 
 // SplitJSON is the JSON-marshalabe representation of a Split
@@ -80,10 +80,10 @@ type IdentifierType struct {
 
 // SchemaSplit is the schema-file YAML-marshalable representation of a split's state
 type SchemaSplit struct {
-	Name    string        `yaml:"name"`
-	Weights yaml.MapSlice `yaml:"weights"`
-	Decided bool          `yaml:"decided,omitempty"`
-	Owner   string        `yaml:"owner,omitempty"`
+	Name    string         `yaml:"name"`
+	Weights map[string]int `yaml:"weights"`
+	Decided bool           `yaml:"decided,omitempty"`
+	Owner   string         `yaml:"owner,omitempty"`
 }
 
 // Schema is the YAML-marshalable representation of the TestTrack schema for

--- a/splitdecisions/splitdecisions.go
+++ b/splitdecisions/splitdecisions.go
@@ -97,7 +97,7 @@ func (s *SplitDecision) ApplyToSchema(schema *serializers.Schema, migrationRepo 
 	for i, candidate := range schema.Splits {
 		if candidate.Name == *s.split {
 			schema.Splits[i].Decided = true
-			weights, err := splits.WeightsFromYAML(candidate.Weights)
+			weights, err := splits.NewWeights(candidate.Weights)
 			if err != nil {
 				return err
 			}
@@ -105,7 +105,7 @@ func (s *SplitDecision) ApplyToSchema(schema *serializers.Schema, migrationRepo 
 			if err != nil {
 				return fmt.Errorf("in split %s in schema: %w", *s.split, err)
 			}
-			schema.Splits[i].Weights = weights.ToYAML()
+			schema.Splits[i].Weights = *weights
 			return nil
 		}
 	}
@@ -119,7 +119,7 @@ func (s *SplitDecision) ApplyToSchema(schema *serializers.Schema, migrationRepo 
 			}
 			schema.Splits = append(schema.Splits, serializers.SchemaSplit{
 				Name:    *s.split,
-				Weights: weights.ToYAML(),
+				Weights: *weights,
 				Decided: true,
 			})
 			return nil

--- a/splitretirements/splitretirements.go
+++ b/splitretirements/splitretirements.go
@@ -96,7 +96,7 @@ func (s *SplitRetirement) SameResourceAs(other migrations.IMigration) bool {
 func (s *SplitRetirement) ApplyToSchema(schema *serializers.Schema, _ migrations.Repository, _idempotently bool) error {
 	for i, candidate := range schema.Splits {
 		if candidate.Name == *s.split {
-			weights, err := splits.WeightsFromYAML(candidate.Weights)
+			weights, err := splits.NewWeights(candidate.Weights)
 			if err != nil {
 				return err
 			}

--- a/splits/splits.go
+++ b/splits/splits.go
@@ -90,6 +90,7 @@ func FromFile(migrationVersion *string, serializable *serializers.SplitYAML) (mi
 	return &Split{
 		migrationVersion: migrationVersion,
 		name:             &serializable.Name,
+		owner:            &serializable.Owner,
 		weights:          weights,
 	}, nil
 }

--- a/splits/weights.go
+++ b/splits/weights.go
@@ -2,9 +2,6 @@ package splits
 
 import (
 	"fmt"
-	"sort"
-
-	"gopkg.in/yaml.v2"
 )
 
 // Weights represents the weightings of a split
@@ -24,37 +21,6 @@ func NewWeights(weights map[string]int) (*Weights, error) {
 	}
 	w := Weights(weights)
 	return &w, nil
-}
-
-// WeightsFromYAML converts YAML-serializable weights to a weights map
-func WeightsFromYAML(yamlWeights yaml.MapSlice) (*Weights, error) {
-	weights := make(map[string]int)
-	for _, item := range yamlWeights {
-		variant, ok := item.Key.(string)
-		if !ok {
-			return nil, fmt.Errorf("variant %v is not a string", item.Key)
-		}
-		weight, ok := item.Value.(int)
-		if !ok {
-			return nil, fmt.Errorf("weighting %v is not an int", item.Value)
-		}
-		weights[variant] = weight
-	}
-	return NewWeights(weights)
-}
-
-// ToYAML converts weights to a YAML-serializable representation
-func (w *Weights) ToYAML() yaml.MapSlice {
-	var variants = make([]string, 0, len(*w))
-	for variant := range *w {
-		variants = append(variants, variant)
-	}
-	sort.Strings(variants)
-	weightsYaml := make(yaml.MapSlice, 0, len(variants))
-	for _, variant := range variants {
-		weightsYaml = append(weightsYaml, yaml.MapItem{Key: variant, Value: (*w)[variant]})
-	}
-	return weightsYaml
 }
 
 // Merge newWeights over weights

--- a/validations/validations.go
+++ b/validations/validations.go
@@ -259,11 +259,7 @@ func VariantExistsInSchema(paramName string, variant *string, split string, sche
 	}
 	for _, schemaSplit := range schema.Splits {
 		if schemaSplit.Name == split {
-			for _, item := range schemaSplit.Weights {
-				v, ok := item.Key.(string)
-				if !ok {
-					return fmt.Errorf("variant %v is not a string", item.Key)
-				}
+			for v := range schemaSplit.Weights {
 				if v == *variant {
 					return nil
 				}


### PR DESCRIPTION
In https://github.com/Betterment/test_track_js_client/pull/99, I'm adding strict typechecking for splits, variants, and identifier types based on the Test Track schema format.

The schema is currently YAML, which TypeScript doesn't support natively. There are other potential solutions to this problem, but I think the simplest solution is to convert the schema file to JSON. It's a generated file, so the readability of YAML and the ability to add comments isn't as valuable.

## Behavior

The CLI will attempt to use `schema.json`, but fallback to `schema.yml`. Projects can switch to JSON with this one-liner:

```bash
ruby -r json -r yaml -e 'puts JSON.pretty_generate(YAML.safe_load(ARGF.read))' testtrack/schema.yml > testtrack/schema.json
```

Linked schemas in `~/testtrack/schemas` can be JSON or YAML.

## Implementation

We use the YAML parser to read both JSON and YAML files, which simplifies things, since all valid JSON is valid YAML.

The use of `yaml.MapSlice` in serializer structs complicated the implementation. Our YAML encoder and the built-in JSON encoder sort map keys, so loading/dumping the schema still produces deterministic output. This change actually simplifies the implementation, since we just deserialize into `map[string]int`.