### PR TITLE
feat: drop schema version tracking entirely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 
-VERSION=1.9.0
+VERSION=1.10.0
 BUILD=`git rev-parse HEAD`
 
 LDFLAGS=-ldflags "-w -s \

--- a/fakeserver/server_test.go
+++ b/fakeserver/server_test.go
@@ -21,7 +21,6 @@ import (
 
 var testSchema = `
 serializer_version: 1
-schema_version: "2020011774023"
 splits:
 - name: test.test_experiment
   weights:
@@ -35,7 +34,6 @@ splits:
 
 var otherTestSchema = `{
   "serializer_version": 1,
-  "schema_version": "2020011774023",
   "splits": [
     {
       "name": "test.json_experiment",

--- a/migrationmanagers/migrationmanagers.go
+++ b/migrationmanagers/migrationmanagers.go
@@ -88,16 +88,7 @@ func (m *MigrationManager) ApplyToSchema(migrationRepo migrations.Repository, id
 		return err
 	}
 
-	err = m.migration.ApplyToSchema(m.schema, migrationRepo, idempotently)
-	if err != nil {
-		return err
-	}
-
-	appliedVersion := m.migration.MigrationVersion()
-	if appliedVersion != nil && m.schema.SchemaVersion < *appliedVersion {
-		m.schema.SchemaVersion = *appliedVersion
-	}
-	return nil
+	return m.migration.ApplyToSchema(m.schema, migrationRepo, idempotently)
 }
 
 // Sync applies the contents of a migration to the TestTrack server
@@ -158,11 +149,6 @@ func (m *MigrationManager) SyncVersion() error {
 
 	if resp.StatusCode != 204 {
 		return fmt.Errorf("got %d status code", resp.StatusCode)
-	}
-
-	appliedVersion := m.migration.MigrationVersion()
-	if m.schema.SchemaVersion < *appliedVersion {
-		m.schema.SchemaVersion = *appliedVersion
 	}
 
 	return nil

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -204,9 +204,6 @@ func applyAllMigrationsToSchema(schema *serializers.Schema) error {
 			return err
 		}
 	}
-	if len(versions) != 0 {
-		schema.SchemaVersion = versions[len(versions)-1]
-	}
 	return nil
 }
 

--- a/schemaloaders/schemaloaders.go
+++ b/schemaloaders/schemaloaders.go
@@ -71,11 +71,10 @@ func (s *SchemaLoader) Load() error {
 		}
 	}
 
+	// The schema body is assumed to reflect every migration on disk (the CLI
+	// always writes them together), so mark them all applied - this is what
+	// lets a freshly bootstrapped server skip replaying history.
 	for _, version := range s.migrationRepo.SortedVersions() {
-		if version > s.schema.SchemaVersion {
-			fmt.Println("Schema load complete, but there are migrations newer than the schema file - run testtrack migrate to apply them.")
-			break
-		}
 		err := migrationmanagers.NewWithServer((*s.migrationRepo)[version], s.server).SyncVersion()
 		if err != nil {
 			return err

--- a/serializers/serializers.go
+++ b/serializers/serializers.go
@@ -90,7 +90,6 @@ type SchemaSplit struct {
 // migration validation and bootstrapping of new ecosystems
 type Schema struct {
 	SerializerVersion  int                 `yaml:"serializer_version" json:"serializer_version"`
-	SchemaVersion      string              `yaml:"schema_version" json:"schema_version"`
 	Splits             []SchemaSplit       `yaml:"splits,omitempty" json:"splits,omitempty"`
 	IdentifierTypes    []IdentifierType    `yaml:"identifier_types,omitempty" json:"identifier_types,omitempty"`
 	RemoteKills        []RemoteKill        `yaml:"remote_kills,omitempty" json:"remote_kills,omitempty"`


### PR DESCRIPTION
**Description**:

Every new migration rewrites the schema's `schema_version` line, so any two branches that add migrations conflict on it. Rather than making that line cleverer, this deletes it: the CLI stops writing `schema_version`, and `schema load` marks every migration on disk as applied instead of comparing against the schema's recorded high-water mark. That's safe because the CLI always writes a migration file and its schema change together, so the schema body already reflects everything in testtrack/migrate.

The tradeoff: if someone hand-copies a migration file into testtrack/migrate without its schema change, `schema load` used to print a warning and leave that migration for `testtrack migrate` to apply against the new server; now it gets marked applied with no diagnostic. That only bites when a migration bypassed `testtrack create` and only on freshly bootstrapped servers.

**Testing Done**:

Ran the new binary against a fresh retail worktree: `create feature_gate` works directly on the existing schema (the diff is just the dropped `schema_version` line plus the new split), a 1.9 binary interleaved with the new one round-trips the schema with no errors, and `schema load` against a stub server marked exactly the 3,366 unique migration versions on disk as applied. Retail's test_track meta specs pass unchanged.
