### PR TITLE
Fix SortAlphabetically's remote-kill comparator

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -210,8 +210,10 @@ func applyAllMigrationsToSchema(schema *serializers.Schema) error {
 // SortAlphabetically sorts the schema's resource slices by their natural keys
 func SortAlphabetically(schema *serializers.Schema) {
 	sort.Slice(schema.RemoteKills, func(i, j int) bool {
-		return schema.RemoteKills[i].Split < schema.RemoteKills[j].Split &&
-			schema.RemoteKills[i].Reason < schema.RemoteKills[j].Reason
+		if schema.RemoteKills[i].Split != schema.RemoteKills[j].Split {
+			return schema.RemoteKills[i].Split < schema.RemoteKills[j].Split
+		}
+		return schema.RemoteKills[i].Reason < schema.RemoteKills[j].Reason
 	})
 	sort.Slice(schema.FeatureCompletions, func(i, j int) bool {
 		return schema.FeatureCompletions[i].FeatureGate < schema.FeatureCompletions[j].FeatureGate

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,0 +1,28 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/Betterment/testtrack-cli/serializers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortAlphabeticallyRemoteKillsIsDeterministic(t *testing.T) {
+	// These three kills are mutually incomparable under the old buggy
+	// comparator (Split < Split && Reason < Reason), which made the written
+	// order depend on input order.
+	kills := []serializers.RemoteKill{
+		{Split: "a_split", Reason: "z_reason"},
+		{Split: "b_split", Reason: "m_reason"},
+		{Split: "c_split", Reason: "a_reason"},
+	}
+	forward := &serializers.Schema{RemoteKills: []serializers.RemoteKill{kills[0], kills[1], kills[2]}}
+	reversed := &serializers.Schema{RemoteKills: []serializers.RemoteKill{kills[2], kills[1], kills[0]}}
+
+	SortAlphabetically(forward)
+	SortAlphabetically(reversed)
+
+	require.Equal(t, forward.RemoteKills, reversed.RemoteKills,
+		"remote kills must sort to the same order regardless of input order")
+	require.Equal(t, []serializers.RemoteKill{kills[0], kills[1], kills[2]}, forward.RemoteKills)
+}


### PR DESCRIPTION
The two-key comparison (`Split < Split && Reason < Reason`) is not a strict weak ordering, so remote_kills order in the written schema depended on input order -- with mutually incomparable kills, `sort.Slice` produces different output for different input orders, causing spurious diffs on schema writes. Standard two-key tiebreak fixes it; test covers the incomparable case.

Found while working on #74.